### PR TITLE
streaming IO and genomes init

### DIFF
--- a/iggtools/__main__.py
+++ b/iggtools/__main__.py
@@ -9,19 +9,19 @@
 # with their own set of command line arguments and subcommand help text.
 #
 # The help text and broad description for the overall iggtools application is found in
-# iggtools.common.argparser.
+# iggtools.common.argparser, and also there are defined any and all arguments that
+# are shared across all subcommands.
 #
-from iggtools.subcommands import aws_batch_init, prokka  # pylint: disable=unused-import
-
-
+from iggtools.subcommands import aws_batch_init, init, prokka  # pylint: disable=unused-import
 from iggtools.common import argparser
 
 
 def main():
-    # The one and only subcommand specified by the user will be invoked with its parsed args.
-    args = argparser.parse_args()
+    parser = argparser.get()
+    args = parser.parse_args()
+    # Invoke subcommand specified in args.
     subcommand_main = args.subcommand_main
-    del args.subcommand_main  # Remove function pointer from args in case someone tries to print args.
+    del args.subcommand_main  # Remove unserializable function pointer from args.
     return subcommand_main(args)
 
 

--- a/iggtools/common/argparser.py
+++ b/iggtools/common/argparser.py
@@ -19,4 +19,4 @@ def get(singleton=[None]):  # pylint: disable=dangerous-default-value
 def add_shared_subcommand_args(parser):
     # Add here any arguments shared by all subcommands.
     parser.add_argument('-f', '--force', action='store_const', const=True, dest='force', help="force rebuild of pre-existing outputs")
-    parser.set_defaults(force=False) 
+    parser.set_defaults(force=False)

--- a/iggtools/common/argparser.py
+++ b/iggtools/common/argparser.py
@@ -16,6 +16,7 @@ def get(singleton=[None]):  # pylint: disable=dangerous-default-value
         singleton[0] = parser
     return parser
 
-
-def parse_args():
-    return get().parse_args()
+def add_shared_subcommand_args(parser):
+    # Add here any arguments shared by all subcommands.
+    parser.add_argument('-f', '--force', action='store_const', const=True, dest='force', help="force rebuild of pre-existing outputs")
+    parser.set_defaults(force=False) 

--- a/iggtools/common/utils.py
+++ b/iggtools/common/utils.py
@@ -65,10 +65,9 @@ class InputStream:
 
     To run through some custom filters,
 
-        with InputStream("/path/to/file.lz4", """awk '{print $2}' | sed 's=foo=bar'""") as stream:
+        with InputStream("/path/to/file.lz4", """awk '{print $2}' | sed 's=foo=bar='""") as stream:
             for filtered_line in stream:
                 print(filtered_line)
-
 
     If your filters include commands like "head" or "tail" that can fail to consume all input,
     make sure to call stream.ignore_errors() before you exit the context.
@@ -77,11 +76,13 @@ class InputStream:
     a local file.  TODO:  In some cases local caching may be desired.
 
     Formats lz4, bz2, gz and plain text are supported.
+
+    Wildcards in path are also supported, but must expand to precisely 1 matching file.
     '''
 
     def __init__(self, path, filters=None, check_path=True):
         if check_path:
-            smart_glob(path, expected=1)
+            path = smart_glob(path, expected=1)[0]
         cat = 'set -o pipefail; '
         if path.startswith("s3://"):
             cat += f"aws s3 --quiet cp {path} -"

--- a/iggtools/common/utils.py
+++ b/iggtools/common/utils.py
@@ -4,6 +4,7 @@ import sys
 import time
 import subprocess
 import multiprocessing
+from fnmatch import fnmatch
 
 
 # Thread-safe and timestamped prints.
@@ -39,7 +40,145 @@ def tsprint(msg):
     tserr(tsfmt(msg))
 
 
-def command(cmd, quiet=False, **kwargs):
+class InputStream:
+    '''
+    Basic usage:
+
+        with InputStream("/path/to/file.lz4") as stream:
+            for line in stream:
+                print(line)
+
+    This may look prettier through decoded():
+
+        with InputStream("/path/to/file.lz4") as stream:
+            for line in decoded(stream):
+                print(line)
+
+    To inspect just the first line,
+
+        with InputStream("/path/to/file.lz4") as stream:
+            print(stream.readline()
+            stream.ignore_errors()
+
+    Failing to read through the entire stream would normally raise an exception,
+    unless you call stream.ignore_errors(), as in the above example.
+
+    To run through some custom filters,
+
+        with InputStream("/path/to/file.lz4", """awk '{print $2}' | sed 's=foo=bar'""") as stream:
+            for filtered_line in stream:
+                print(filtered_line)
+
+
+    If your filters include commands like "head" or "tail" that can fail to consume all input,
+    make sure to call stream.ignore_errors() before you exit the context.
+
+    If the path is in S3, data is streamed from S3 directly, without downloading to
+    a local file.  TODO:  In some cases local caching may be desired.
+
+    Formats lz4, bz2, gz and plain text are supported.
+    '''
+
+    def __init__(self, path, filters=None, check_path=True):
+        if check_path:
+            smart_glob(path, expected=1)
+        cat = 'set -o pipefail; '
+        if path.startswith("s3://"):
+            cat += f"aws s3 --quiet cp {path} -"
+        else:
+            cat += f"cat {path}"
+        if path.endswith(".lz4"):
+            cat += " | lz4 -dc"
+        elif path.endswith(".bz2"):
+            cat += " | lbzip2 -dc"
+        elif path.endswith(".gz"):
+            cat += " | gzip -dc"
+        if filters:
+            cat += f" | {filters}"
+        self.cat = cat
+        self.path = path
+        self.subproc = 0
+        self.ignore_called_process_errors = False
+
+    def ignore_errors(self):
+        """Exiting the context before consuming all data would normally raise an exception.  To suppress that, call this function."""
+        self.ignore_called_process_errors = True
+
+    def __enter__(self):
+        self.subproc = command(self.cat, popen=True, stdout=subprocess.PIPE)
+        self.subproc.__enter__()
+        self.subproc.stdout.ignore_errors = self.ignore_errors
+        return self.subproc.stdout  # Note the subject of the WITH statement is the subprocess STDOUT
+
+    def __exit__(self, etype, evalue, etraceback):
+        result = self.subproc.__exit__(etype, evalue, etraceback)  # pylint: disable=assignment-from-no-return
+        if not self.ignore_called_process_errors:
+            returncode = self.subproc.returncode
+            if returncode != 0:
+                msg = f"Non-zero exit code {returncode} from reader of {self.path}."
+                if evalue:
+                    # Only a warning as we don't want to silence the other exception.
+                    tsprint(f"WARNING: {msg}")
+                else:
+                    # Surface this as an error.
+                    assert returncode == 0, msg
+        return result
+
+
+class OutputStream:
+    '''
+    Same idea as InputStream, but for output.  Handles compression etc transparently.
+    '''
+
+    def __init__(self, path, filters=None):
+        if path.startswith("s3://"):
+            cat = f"aws s3 --quiet cp - {path}"
+        else:
+            cat = f"cat > {path}"
+        if path.endswith(".lz4"):
+            cat = "lz4 -c | " + cat
+        elif path.endswith(".bz2"):
+            cat = "lbzip2 -c | " + cat
+        elif path.endswith(".gz"):
+            cat = "gzip -c | " + cat
+        if filters:
+            cat = f"{filters} | " + cat
+        self.cat = 'set -o pipefail; ' + cat
+        self.path = path
+        self.subproc = 0
+        self.ignore_called_process_errors = False
+
+    def ignore_errors(self):
+        """Exiting the context before consuming all data would normally raise an exception.  To suppress that, call this function."""
+        self.ignore_called_process_errors = True
+
+    def __enter__(self):
+        self.subproc = command(self.cat, popen=True, stdin=subprocess.PIPE)
+        self.subproc.__enter__()
+        self.subproc.stdin.ignore_errors = self.ignore_errors
+        return self.subproc.stdin  # Note the subject of the WITH statement is the subprocess STDIN
+
+    def __exit__(self, etype, evalue, etraceback):
+        result = self.subproc.__exit__(etype, evalue, etraceback)  # pylint: disable=assignment-from-no-return
+        if not self.ignore_called_process_errors:
+            returncode = self.subproc.returncode
+            if returncode != 0:
+                msg = f"Non-zero exit code {returncode} from reader of {self.path}."
+                if evalue:
+                    # Only a warning as we don't want to silence the other exception.
+                    tsprint(f"WARNING: {msg}")
+                else:
+                    # Surface this as an error.
+                    assert returncode == 0, msg
+        return result
+
+
+def decoded(stream):
+    for line in stream:
+        yield line.decode('utf-8').rstrip('\n')
+
+
+def command(cmd, quiet=False, popen=False, **kwargs):
     """Echo and execute specified cmd.  If string, execute through BASH.  In that case, cmd could be a pipeline.  Raise an exception if exit code non-zero.  Set check=False if you don't want that exception.  Set quiet=True if you don't want to echo the command.  The result is https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess."""
     # This requires version >= 3.6
     assert "shell" not in kwargs, "Please do not override shell.  It is automatically True if command is a string, False if list."
@@ -47,14 +186,16 @@ def command(cmd, quiet=False, **kwargs):
     if not quiet:
         command_str = cmd if shell else " ".join(cmd)
         tsprint(repr(command_str))
-    subproc_args = {
-        "check": True
-    }
+    subproc_args = {}
+    if not popen:
+        subproc_args["check"] = True
     if shell:
         # By default docker tries a different shell with restricted functionality,
         # and weird handling of pipe errors.  Let's specify BASH here to be safe.
         subproc_args["executable"] = "/bin/bash"
     subproc_args.update(**kwargs)
+    if popen:
+        return subprocess.Popen(cmd, shell=shell, **subproc_args)
     return subprocess.run(cmd, shell=shell, **subproc_args)
 
 
@@ -66,6 +207,66 @@ def command_output(cmd, quiet=False, **kwargs):
 def backtick(cmd, **kwargs):
     """Execute specified cmd without echoing it.  Capture and return its stdout, stripping any whitespace."""
     return command_output(cmd, quiet=True, **kwargs).strip()
+
+
+def smart_glob(pattern, expected=range(0, sys.maxsize), memory=None):
+    """Return list of files that match specified pattern.  Raise exception if item count unexpected.  Memoize if memory dict provided."""
+    pdir, file_pattern = pattern.rsplit("/", 1)
+    def match_pattern(filename):
+        return fnmatch(filename, file_pattern)
+    matching_files = list(filter(match_pattern, smart_ls(pdir, memory=memory)))
+    actual = len(matching_files)
+    expected_str = str(expected)
+    if isinstance(expected, int):
+        expected = [expected]
+    assert actual in expected, f"Expected {expected_str} file(s) for {pattern}, found {actual}"
+    return [f"{pdir}/{mf}" for mf in sorted(matching_files)]
+
+
+find_files = smart_glob
+
+
+def smart_ls(pdir, missing_ok=True, memory=None):
+    "Return a list of files in pdir.  This pdir can be local or in s3.  If memory dict provided, use it to memoize.  If missing_ok=True, swallow errors (default)."
+    result = memory.get(pdir) if memory else None
+    if result == None:
+        try:
+            if pdir.startswith("s3://"):
+                s3_dir = pdir
+                if not s3_dir.endswith("/"):
+                    s3_dir += "/"
+                output = backtick(["aws", "s3", "ls", s3_dir])
+                rows = output.strip().split('\n')
+                result = [r.split()[-1] for r in rows]
+            else:
+                output = backtick(["ls", pdir])
+                result = output.strip().split('\n')
+        except Exception as e:
+            msg = f"Could not read directory: {pdir}"
+            if missing_ok and isinstance(e, subprocess.CalledProcessError):
+                print(f"INFO: {msg}")
+                result = []
+            else:
+                print(f"ERROR: {msg}")
+                raise
+        if memory != None:
+            memory[pdir] = result
+    return result
+
+
+def parse_table(lines, columns, decode=True):
+    if decode:
+        lines = decoded(lines)
+    headers = next(lines).split('\t')  # pylint: disable=stop-iteration-return
+    column_indexes = []
+    for c in columns:
+        assert c in headers, f"Column not found in table headers: {c}"
+        column_indexes.append(headers.index(c))
+    for i, l in enumerate(lines):
+        values = l.split('\t')
+        if len(headers) != len(values):
+            assert False, f"Line {i} has {len(values)} columns;  was expecting {len(headers)}."
+        yield [values[i] for i in column_indexes]
 
 
 if __name__ == "__main__":

--- a/iggtools/params/inputs.py
+++ b/iggtools/params/inputs.py
@@ -1,0 +1,6 @@
+# These are the "raw" inputs to the IGGTools database construction subcommands.
+# See https://github.com/czbiohub/iggtools/wiki#inputs
+
+iggdb2 = "s3://jason.shi-bucket/IGGdb2.0"
+genomes2species = f"{iggdb2}/genomes2species.tab"
+alt_species_ids = f"{iggdb2}/alt_species_ids.tsv"

--- a/iggtools/params/outputs.py
+++ b/iggtools/params/outputs.py
@@ -1,0 +1,5 @@
+# The "output" or built DB layout in S3.
+# See https://github.com/czbiohub/iggtools/wiki#target-layout-in-s3
+
+igg = "s3://microbiome-igg/2.0"
+genomes = f"{igg}/genomes.tsv"

--- a/iggtools/subcommands/aws_batch_init.py
+++ b/iggtools/subcommands/aws_batch_init.py
@@ -30,7 +30,8 @@ def main(args):
 def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-value
     subparser = singleton[0]
     if not subparser:
-        subparser = argparser.get().subparsers.add_parser('aws_batch_init', help='inialize AWS Batch instance')
+        summary = 'inialize AWS Batch instance'
+        subparser = argparser.get().subparsers.add_parser('aws_batch_init', description=summary, help=summary)
         subparser.set_defaults(subcommand_main=main)
         argparser.add_shared_subcommand_args(subparser)
         singleton[0] = subparser

--- a/iggtools/subcommands/aws_batch_init.py
+++ b/iggtools/subcommands/aws_batch_init.py
@@ -7,19 +7,24 @@ def nvme_size_str():
     return command_output("""df -m /mnt/nvme | awk '{print $2}' | tail -1""", check=False)
 
 
-def init_nvme():
+def init_nvme(args):
     # TODO:  Generalize the magic numbers 838 and 1715518 (those are for AWS instance type r5.12xlarge).
     if nvme_size_str() != '1715518':
         # Raid, format, and mount the NVME drives attached to this instance.
+        tsprint("Initializing instance NVME storage.")
         command("""set -o pipefail; lsblk | grep 838 | awk '{print "/dev/"$1}' | xargs -n 10 s3mi raid nvme""")
         assert nvme_size_str() == '1715518', "Failed to initialize and mount instance NVME storage."
+    else:
+        tsprint("Instance NVME storage previously initialized.")
+        if args.force:
+            tsprint("Ignoring --force argument.  It is usually unnecessary to reinitialize AWS instance storage.")
 
 
 def main(args):
-    tsprint(f"Doing important work in subcommand {args.subcommand}.")
+    tsprint(f"Executing iggtools subcommand {args.subcommand}.")
     tsprint(vars(args))
     assert args.subcommand == "aws_batch_init"
-    init_nvme()
+    init_nvme(args)
 
 
 def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-value
@@ -27,6 +32,7 @@ def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-v
     if not subparser:
         subparser = argparser.get().subparsers.add_parser('aws_batch_init', help='inialize AWS Batch instance')
         subparser.set_defaults(subcommand_main=main)
+        argparser.add_shared_subcommand_args(subparser)
         singleton[0] = subparser
 
 

--- a/iggtools/subcommands/example_a.py
+++ b/iggtools/subcommands/example_a.py
@@ -28,6 +28,7 @@ def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-v
         subparser = argparser.get().subparsers.add_parser('example_a', help='run subcommand example_a')
         subparser.add_argument('-1', '--one', action='store_const', const=1, dest='test_value', help="test_value := 1")
         subparser.set_defaults(subcommand_main=main)
+        argparser.add_shared_subcommand_args(subparser)
         singleton[0] = subparser
 
 

--- a/iggtools/subcommands/example_a.py
+++ b/iggtools/subcommands/example_a.py
@@ -25,7 +25,8 @@ def main(args):
 def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-value
     subparser = singleton[0]
     if not subparser:
-        subparser = argparser.get().subparsers.add_parser('example_a', help='run subcommand example_a')
+        summary = 'run subcommand example_a'
+        subparser = argparser.get().subparsers.add_parser('example_a', description=summary, help=summary)
         subparser.add_argument('-1', '--one', action='store_const', const=1, dest='test_value', help="test_value := 1")
         subparser.set_defaults(subcommand_main=main)
         argparser.add_shared_subcommand_args(subparser)

--- a/iggtools/subcommands/example_b.py
+++ b/iggtools/subcommands/example_b.py
@@ -25,7 +25,8 @@ def main(args):
 def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-value
     subparser = singleton[0]
     if not subparser:
-        subparser = argparser.get().subparsers.add_parser('example_b', help='run subcommand example_b')
+        summary = 'run subcommand example_b'
+        subparser = argparser.get().subparsers.add_parser('example_b', description=summary, help=summary)
         subparser.add_argument('-2', '--two', action='store_const', const=2, dest='test_value', help="test_value := 2")
         subparser.set_defaults(subcommand_main=main)
         argparser.add_shared_subcommand_args(subparser)

--- a/iggtools/subcommands/example_b.py
+++ b/iggtools/subcommands/example_b.py
@@ -28,6 +28,7 @@ def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-v
         subparser = argparser.get().subparsers.add_parser('example_b', help='run subcommand example_b')
         subparser.add_argument('-2', '--two', action='store_const', const=2, dest='test_value', help="test_value := 2")
         subparser.set_defaults(subcommand_main=main)
+        argparser.add_shared_subcommand_args(subparser)
         singleton[0] = subparser
 
 

--- a/iggtools/subcommands/init.py
+++ b/iggtools/subcommands/init.py
@@ -1,0 +1,61 @@
+from iggtools.common import argparser
+from iggtools.common.utils import tsprint, find_files, InputStream, OutputStream, parse_table
+from iggtools.params import inputs, outputs
+
+
+def init(args):
+    """
+    Input spec: https://github.com/czbiohub/iggtools/wiki#inputs
+    Output spec: https://github.com/czbiohub/iggtools/wiki#target-layout-in-s3
+    """
+
+    msg = f"Building {outputs.genomes}."
+    if find_files(outputs.genomes):
+        if not args.force:
+            tsprint(f"Destination {outputs.genomes} already exists.  Specify --force to overwrite.")
+            return
+        msg = f"Rebuilding {outputs.genomes}."
+    tsprint(msg)
+
+    id_remap = {}
+    with InputStream(inputs.alt_species_ids) as ids:
+        for row in parse_table(ids, ["alt_species_id", "species_id"]):
+            new_id, old_id = row
+            id_remap[old_id] = new_id
+
+
+    seen_genomes, seen_species = set(), set()
+    with OutputStream(outputs.genomes) as out:
+
+        target_columns = ["genome", "species", "representative", "genome_is_representative"]
+        out.write(("\t".join(target_columns) + "\n").encode('utf-8'))
+
+        with InputStream(inputs.genomes2species) as g2s:
+            for row in parse_table(g2s, ["MAG_code", "Species_id"]):
+                genome, representative = row
+                species = id_remap[representative]
+                genome_is_representative = str(int(genome == representative))
+                target_row = [genome, species, representative, genome_is_representative]
+                out.write(("\t".join(target_row) + "\n").encode('utf-8'))
+                seen_genomes.add(genome)
+                seen_species.add(species)
+
+    tsprint(f"Emitted {len(seen_genomes)} genomes and {len(seen_species)} species to {outputs.genomes}.")
+
+
+def main(args):
+    tsprint(f"Executing iggtools subcommand {args.subcommand}.")
+    assert args.subcommand == "init"
+    init(args)
+
+
+def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-value
+    subparser = singleton[0]
+    if not subparser:
+        subparser = argparser.get().subparsers.add_parser('init', help=f"initialize target {outputs.genomes}")
+        subparser.set_defaults(subcommand_main=main)
+        argparser.add_shared_subcommand_args(subparser)
+        singleton[0] = subparser
+
+
+register_argparser()

--- a/iggtools/subcommands/init.py
+++ b/iggtools/subcommands/init.py
@@ -23,7 +23,6 @@ def init(args):
             new_id, old_id = row
             id_remap[old_id] = new_id
 
-
     seen_genomes, seen_species = set(), set()
     with OutputStream(outputs.genomes) as out:
 
@@ -52,7 +51,8 @@ def main(args):
 def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-value
     subparser = singleton[0]
     if not subparser:
-        subparser = argparser.get().subparsers.add_parser('init', help=f"initialize target {outputs.genomes}")
+        summary = f"initialize target {outputs.genomes}"
+        subparser = argparser.get().subparsers.add_parser('init', description=summary, help=summary)
         subparser.set_defaults(subcommand_main=main)
         argparser.add_shared_subcommand_args(subparser)
         singleton[0] = subparser

--- a/iggtools/subcommands/prokka.py
+++ b/iggtools/subcommands/prokka.py
@@ -11,7 +11,8 @@ def main(args):
 def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-value
     subparser = singleton[0]
     if not subparser:
-        subparser = argparser.get().subparsers.add_parser('prokka', help='run genome annotation tool prokka')
+        summary = 'run genome annotation tool prokka'
+        subparser = argparser.get().subparsers.add_parser('prokka', description=summary, help=summary)
         subparser.set_defaults(subcommand_main=main)
         argparser.add_shared_subcommand_args(subparser)
         singleton[0] = subparser

--- a/iggtools/subcommands/prokka.py
+++ b/iggtools/subcommands/prokka.py
@@ -3,7 +3,7 @@ from iggtools.common.utils import tsprint
 
 
 def main(args):
-    tsprint(f"Doing important work in subcommand prokka.")
+    tsprint(f"Executing iggtools subcommand {args.subcommand}.")
     tsprint(vars(args))
     assert args.subcommand == "prokka"
 
@@ -13,6 +13,7 @@ def register_argparser(singleton=[None]):  # pylint: disable=dangerous-default-v
     if not subparser:
         subparser = argparser.get().subparsers.add_parser('prokka', help='run genome annotation tool prokka')
         subparser.set_defaults(subcommand_main=main)
+        argparser.add_shared_subcommand_args(subparser)
         singleton[0] = subparser
 
 


### PR DESCRIPTION
Classes InputStream and OutputStream to handle transparently compressed, local, and s3 files.

Utility functions smart_ls, smart_glob, and find_files that handle both local and s3 files.

Execution trace of new init subcommand, which generates the target DB table of contents:
```
(exon) p3 -m iggtools init --force                                                                                                                       Thu 6:42pm
1563500528.9:  Executing iggtools subcommand init.
1563500529.4:  Rebuilding s3://microbiome-igg/2.0/genomes.tsv.
1563500530.0:  'set -o pipefail; aws s3 --quiet cp s3://jason.shi-bucket/IGGdb2.0/alt_species_ids.tsv -'
1563500530.6:  'set -o pipefail; aws s3 --quiet cp - s3://microbiome-igg/2.0/genomes.tsv'
1563500531.1:  'set -o pipefail; aws s3 --quiet cp s3://jason.shi-bucket/IGGdb2.0/genomes2species.tab -'
1563500544.4:  Emitted 286997 genomes and 4644 species to s3://microbiome-igg/2.0/genomes.tsv.
```