### PR TITLE
Boris/upload and multiple species

### DIFF
--- a/iggtools/__init__.py
+++ b/iggtools/__init__.py
@@ -3,4 +3,4 @@
 import sys
 assert sys.version_info >= (3, 7), "Python version >= 3.7 is required."
 
-version = "0.4"
+version = "0.5"

--- a/iggtools/common/argparser.py
+++ b/iggtools/common/argparser.py
@@ -56,6 +56,12 @@ def _add_shared_subcommand_args(subparser):
                            dest='debug',
                            help="debug mode, e.g. skip cleanup on error, extra prints, etc.")
     subparser.set_defaults(debug=False)
+    subparser.add_argument('--slave_mode',
+                           action='store_const',
+                           const=True,
+                           dest='slave_mode',
+                           help="slave mode is reserved for master-slave decomposition (do not use directly)")
+    subparser.set_defaults(slave=False)
 
 
 # ----------------------------------------------------- #

--- a/iggtools/common/argparser.py
+++ b/iggtools/common/argparser.py
@@ -49,6 +49,13 @@ def _add_shared_subcommand_args(subparser):
                            dest='force',
                            help="force rebuild of pre-existing outputs")
     subparser.set_defaults(force=False)
+    subparser.add_argument('-g',
+                           '--debug',
+                           action='store_const',
+                           const=True,
+                           dest='debug',
+                           help="debug mode, e.g. skip cleanup on error, extra prints, etc.")
+    subparser.set_defaults(debug=False)
 
 
 # ----------------------------------------------------- #

--- a/iggtools/common/utils.py
+++ b/iggtools/common/utils.py
@@ -425,5 +425,19 @@ def reordered_dict(d, key_order):
     return {k: d[k] for k in key_order}
 
 
+def flatten(l):
+    return [item for sublist in l for item in sublist]
+
+
+@retry
+def upload(src, dst):
+    command(f"set -o pipefail; lz4 -c {src} | aws s3 cp --only-show-errors - {dst}")
+
+
+def upload_star(srcdst):
+    src, dst = srcdst
+    return upload(src, dst)
+
+
 if __name__ == "__main__":
     tsprint(f"Hello from {backtick('pwd')}.  Put tests here.")

--- a/iggtools/subcommands/build_pangenome.py
+++ b/iggtools/subcommands/build_pangenome.py
@@ -78,7 +78,13 @@ def vsearch(percent_id, genes, num_threads=num_vcpu):
     if find_files(centroids) and find_files(uclust):
         tsprint(f"Found vsearch results at percent identity {percent_id} from prior run.")
     else:
-        command(f"vsearch --quiet --cluster_fast {genes} --id {percent_id/100.0} --threads {num_threads} --centroids {centroids} --uc {uclust}")
+        try:
+            command(f"vsearch --quiet --cluster_fast {genes} --id {percent_id/100.0} --threads {num_threads} --centroids {centroids} --uc {uclust}")
+        except:
+            # Do not keep bogus zero-length files;  those are harmful if we rerun in place.
+            command(f"mv {centroids} {centroids}.bogus", check=False)
+            command(f"mv {uclust} {uclust}.bogus", check=False)
+            raise
     return centroids, uclust #, log
 
 

--- a/iggtools/subcommands/build_pangenome.py
+++ b/iggtools/subcommands/build_pangenome.py
@@ -167,6 +167,8 @@ def build_pangenome(args):
         msg = msg.replace("Building", "Rebuilding")
     tsprint(msg)
 
+    command(f"aws s3 rm --recursive {pangenome_file(representative_id, '')}")
+
     cleaned = multiprocessing_map(clean_genes, species_genomes_ids)
 
     command("rm -f genes.ffn")


### PR DESCRIPTION
Build multiple species running at most 3 concurrent vsearch 99 clusterings.

Master/slave pattern works as follows.

1.  The master parses the table of contents and the --species arg to figure out the list of species ids which need to have their pangenomes built. 

2.  The master then runs each species in a thread (via threadpool with 10 threads).   Each species thread first checks if the species has been built before (if destination already exists), and only if not, or if --force, starts a subshell slave for its corresponding species.

3.  A semaphore ensures at most 3 slaves run in parallel (even though there are 10 threads in the thread pool).  That way we can quickly skip over species that have already been built, using 10-way parallelism to check if results exist in s3;  but we only build 3 species in parallel not to overload the instance (because vsearch is quite intensive).

Examples below.

Build 3 specific species:

`p3 -m iggtools build_pangenome -s 103643,102643,101643`

Built all species that have ids 643 modulo 100000:

`p3 -m iggtools build_pangenome -s 643:100000`

If you are iterating on development, specify the `--debug` flag, that will ensure workdirs are not cleaned up, so you can fix bugs and rerun.
