### PR TITLE
midas run_genes ported to iggtools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,14 @@ MAINTAINER MICROBIOME-IGG Contributors bdimitrov@chanzuckerberg.com
 # Ubuntu
 RUN apt-get update && apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 RUN apt-get install -y apt-utils
-RUN apt-get install -y pkg-config bsdtar alien build-essential libbz2-dev liblz4-tool lbzip2 zlib1g-dev zip unzip
+RUN apt-get install -y pkg-config bsdtar alien build-essential libbz2-dev liblz4-tool lbzip2 zlib1g-dev zip unzip liblzma-dev
 RUN apt-get install -y sysstat emacs-nox autoconf gcc g++ curl wget gdebi-core git make perl cmake
 
 # python 3.7
-RUN apt-get install -y software-properties-common
+RUN apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update && apt-get install -y python3.7
+RUN apt-get install -y python3.7-dev  # needed for pysam
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2
 RUN apt-get install -y python3-pip
 
@@ -38,14 +39,7 @@ RUN git clone https://github.com/tseemann/prokka.git && /usr/local/prokka/bin/pr
 RUN ln -sf /usr/local/prokka/bin/prokka /usr/local/bin/prokka
 RUN prokka --version
 
-# In future we should append a layer that re-installs tbl2asn, which is a component
-# of blast that expires after 6 months, and is needed by prokka.  Uncomment this layer
-# when your jobs started failing in Prokka with error that tbl2asn is expired.
-# RUN wget ftp://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/linux.tbl2asn.gz && \
-#    gunzip linux.tbl2asn.gz && \
-#    mv linux.tbl2asn tbl2asn && \
-#    chmod +x tbl2asn && \
-#    mv tbl2asn /usr/local/prokka/binaries/linux/
+RUN pip3 install pysam
 
 # AWS instance setup
 RUN apt-get install -y mdadm xfsprogs htop
@@ -56,6 +50,16 @@ RUN apt-get install -y sudo
 # aws
 RUN pip3 install awscli --upgrade
 RUN pip3 install --upgrade 'git+git://github.com/chanzuckerberg/s3mi.git'
+
+# LEAVE THIS LAST:
+# This layer re-installs tbl2asn, which is a component of blast that expires after 6 months,
+# and is needed by prokka.  Force rebuild of this layer when your jobs start failing in Prokka
+# with error message indicating that tbl2asn has expired.
+RUN wget ftp://ftp.ncbi.nih.gov/toolbox/ncbi_tools/converters/by_program/tbl2asn/linux.tbl2asn.gz && \
+    gunzip linux.tbl2asn.gz && \
+    mv linux.tbl2asn tbl2asn && \
+    chmod +x tbl2asn && \
+    mv tbl2asn /usr/local/prokka/binaries/linux/
 
 # Cleanup
 RUN rm -rf /tmp/*

--- a/iggtools/__init__.py
+++ b/iggtools/__init__.py
@@ -3,4 +3,4 @@
 import sys
 assert sys.version_info >= (3, 7), "Python version >= 3.7 is required."
 
-version = "0.11"
+version = "0.12"

--- a/iggtools/__main__.py
+++ b/iggtools/__main__.py
@@ -9,7 +9,7 @@
 # with their own set of command line arguments and subcommand help text -- aside from
 # the shared arguments and shared help text defined in iggtools.common.argparser.
 #
-from iggtools.subcommands import aws_batch_init, aws_batch_submit, init, build_pangenome, import_uhgg, annotate_genes, build_marker_genes, collate_repgenome_markers, midas_run_species  # pylint: disable=unused-import
+from iggtools.subcommands import aws_batch_init, aws_batch_submit, init, build_pangenome, import_uhgg, annotate_genes, build_marker_genes, collate_repgenome_markers, midas_run_species, midas_run_genes  # pylint: disable=unused-import
 from iggtools.common.argparser import parse_args
 
 

--- a/iggtools/common/utils.py
+++ b/iggtools/common/utils.py
@@ -316,23 +316,21 @@ def select_from_tsv(input_lines, selected_columns=None, schema=None, result_stru
 
     the generator
 
-        select_from_tsv(input_stream)
+        select_from_tsv(input_stream, selected_columns=["name", "height"])
 
     would yield
 
-       ("tommy", "9", "120"),
-       ("masha", "7", "122"),
+       ("tommy", "120"),
+       ("masha", "122"),
        ...
 
-    It's possible to request just certain columns
+    Note how in the above example all values returned are strings.
 
-        select_from_tsv(input_stream, selected_columns=["name", "height"])
+    Column type information may be specified as follows
 
-    Optionally, column type information may be specified
+        select_from_tsv(input_stream, selected_columns={"name": str, "height": float})
 
-        select_from_tsv(input_stream, selected_columns={"name":str, "height": float})
-
-    affecting the result as follows
+    yielding
 
         ("tommy", 120.0),
         ("masha", 122.0),
@@ -342,7 +340,7 @@ def select_from_tsv(input_lines, selected_columns=None, schema=None, result_stru
 
         select_from_tsv(input_stream, selected_columns=["name", "height"], schema={"name": str, "age": int, "height": float})
 
-    Conversely, specifyng a schema argument means the first line of input is expected to contain values, not columnd headers.
+    Specifyng a schema argument means the first line of input should contain values, not columnd headers.
 
     Type information may be specified in either the selected_columns or the schema argument.
 
@@ -352,7 +350,11 @@ def select_from_tsv(input_lines, selected_columns=None, schema=None, result_stru
        {"name": "masha", "height": 122.0},
        ...
 
+    When a schema argument is provided, leaving selected_columns unspecified is equivalent to selecting all columns from the schema.
+
+    At least one of the schema or selected_columns arguments must be specified, even if the schema could be inferred from the input headers.  This makes applications more robust.
     """
+    assert schema != None or selected_columns != None, "at least one of these arguments must be specified"
     lines = strip_eol(input_lines)
     j = 0
     if schema == None:

--- a/iggtools/common/utils.py
+++ b/iggtools/common/utils.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 import subprocess
+import json
 import multiprocessing
 from multiprocessing.pool import ThreadPool
 import random
@@ -302,24 +303,136 @@ def smart_ls(pdir, missing_ok=True, memory=None):
     return result
 
 
-def parse_table(lines, columns, headers=None):
-    lines = strip_eol(lines)
-    if not headers:
+def select_from_tsv(input_lines, selected_columns=None, schema=None, result_structure=tuple, default_column_type=str):
+    """
+    Parse selected_columns from a table represented in tab-separated-values format (TSV).
+
+    For example, given an input_stream of lines
+
+        "name\tage\theight\n",
+        "tommy\t9\t120\n",
+        "masha\t7\t122\n",
+        ...
+
+    the generator
+
+        select_from_tsv(input_stream)
+
+    would yield
+
+       ("tommy", "9", "120"),
+       ("masha", "7", "122"),
+       ...
+
+    It's possible to request just certain columns
+
+        select_from_tsv(input_stream, selected_columns=["name", "height"])
+
+    Optionally, column type information may be specified
+
+        select_from_tsv(input_stream, selected_columns={"name":str, "height": float})
+
+    affecting the result as follows
+
+        ("tommy", 120.0),
+        ("masha", 122.0),
+        ...
+
+    If the first line in the input does not list all column headers, the schema must be provided as an additional argument
+
+        select_from_tsv(input_stream, selected_columns=["name", "height"], schema={"name": str, "age": int, "height": float})
+
+    Conversely, specifyng a schema argument means the first line of input is expected to contain values, not columnd headers.
+
+    Type information may be specified in either the selected_columns or the schema argument.
+
+    Requesting result_structure=dict will change the output to
+
+       {"name": "tommy", "height": 120.0},
+       {"name": "masha", "height": 122.0},
+       ...
+
+    """
+    lines = strip_eol(input_lines)
+    j = 0
+    if schema == None:
+        # the first line is expected to list all column names (headers)
         headers = next(lines).split('\t')  # pylint: disable=stop-iteration-return
+        schema = headers
+        j = 1
+    if not isinstance(schema, dict):
+        schema = {c: default_column_type for c in schema}
+    headers = list(schema.keys())
+    # Ensure "selected_columns" is an ordered dict of {column_name: column_type} and "schema" is a superdict of "columns".
+    if selected_columns == None:
+        # Return all columns
+        selected_columns = dict(schema)
+    if not isinstance(selected_columns, dict):
+        selected_columns = {c: default_column_type for c in selected_columns}
+    # Merge column type information from schema and selected_columns
+    for c in schema:
+        if schema[c] == default_column_type:
+            schema[c] = selected_columns.get(c, schema[c])
+    for c in selected_columns:
+        if selected_columns[c] == default_column_type:
+            selected_columns[c] = schema.get(c, selected_columns[c])
     column_indexes = []
-    for c in columns:
+    for c in selected_columns:
         assert c in headers, f"Column not found in table headers: {c}"
         column_indexes.append(headers.index(c))
+        assert schema[c] == selected_columns[c], f"Conflicting types for column {c}."
+    column_types = list(selected_columns.values())
+    column_names = list(selected_columns.keys())
     for i, l in enumerate(lines):
         values = l.split('\t')
         if len(headers) != len(values):
-            assert False, f"Line {i} has {len(values)} columns;  was expecting {len(headers)}."
-        yield [values[i] for i in column_indexes]
+            assert False, f"Line {i + j} has {len(values)} columns;  was expecting {len(headers)}."
+        # type-convert and reorder values as specified in schema
+        ordered_values = (ctype(values[ci]) for ci, ctype in zip(column_indexes, column_types))
+        if result_structure in (tuple, list):
+            yield result_structure(ordered_values)
+        else: # dict
+            yield result_structure((c, val) for c, val in zip(column_names, ordered_values))
 
 
-def parse_table_as_rowdicts(lines, columns, headers=None):
-    for rowlist in parse_table(lines, columns, headers):
-        yield dict(zip(columns, rowlist))
+def _test_select_from_tsv():
+    # Unit tests for the select_from_tsv function
+    unlabeled_test_data = [
+        "tommy\t9\t120\n",
+        "masha\t7\t122\n",
+    ]
+    test_data_with_headers = [
+        "name\tage\theight"
+    ] + unlabeled_test_data
+
+    result_tuples = [
+        ("tommy", 120.0),
+        ("masha", 122.0)
+    ]
+    result_tuples_height_name = [
+        (120.0, "tommy"),
+        (122.0, "masha")
+    ]
+    result_dicts_age_name = [
+        {"age": 9, "name": "tommy"},
+        {"age": 7, "name": "masha"}
+    ]
+
+    r = list(select_from_tsv(unlabeled_test_data, ["name", "height"], {"name": str, "age": int, "height": float}))
+    assert r == result_tuples, json.dumps(r, indent=4)
+
+    r = list(select_from_tsv(unlabeled_test_data, {"name": str, "height": float}, ["name", "age", "height"]))
+    assert r == result_tuples, json.dumps(r, indent=4)
+
+    r = list(select_from_tsv(test_data_with_headers, {"height": float, "name": str}))
+    assert r == result_tuples_height_name, json.dumps(r, indent=4)
+
+    r = list(select_from_tsv(test_data_with_headers, {"age": int, "name": str}, result_structure=dict))
+    assert r == result_dicts_age_name, json.dumps(r, indent=4)
+
+
+# Just run this every time the module is imported.   Eventually put in the test section in main below.
+_test_select_from_tsv()
 
 
 def retry(operation, MAX_TRIES=3):

--- a/iggtools/models/uhgg.py
+++ b/iggtools/models/uhgg.py
@@ -1,7 +1,7 @@
 # A model for the UHGG collection of genomes (aka UHGG database).
 from collections import defaultdict
 from iggtools.params.outputs import genomes as TABLE_OF_CONTENTS
-from iggtools.common.utils import parse_table, sorted_dict, InputStream
+from iggtools.common.utils import select_from_tsv, sorted_dict, InputStream
 
 
 class UHGG:  # pylint: disable=too-few-public-methods
@@ -18,7 +18,7 @@ def _UHGG_load(toc_tsv, deep_sort=False):
     representatives = {}
     genomes = {}
     with InputStream(toc_tsv) as table_of_contents:
-        for row in parse_table(table_of_contents, ["genome", "species", "representative", "genome_is_representative"]):
+        for row in select_from_tsv(table_of_contents, selected_columns=["genome", "species", "representative", "genome_is_representative"]):
             genome_id, species_id, representative_id, _ = row
             species[species_id][genome_id] = row
             representatives[species_id] = representative_id

--- a/iggtools/subcommands/__init__.py
+++ b/iggtools/subcommands/__init__.py
@@ -1,2 +1,2 @@
 # This helps pylint find all subcommands.
-__all__ = ["aws_batch_init", "aws_batch_submit", "init", "build_pangenome", "import_uhgg", "annotate_genes", "build_marker_genes", "collate_repgenome_markers", "midas_run_species", "example_subcommand"]
+__all__ = ["aws_batch_init", "aws_batch_submit", "init", "build_pangenome", "import_uhgg", "annotate_genes", "build_marker_genes", "collate_repgenome_markers", "midas_run_species", "midas_run_genes", "example_subcommand"]

--- a/iggtools/subcommands/build_pangenome.py
+++ b/iggtools/subcommands/build_pangenome.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from multiprocessing import Semaphore
 import Bio.SeqIO
 from iggtools.common.argparser import add_subcommand, SUPPRESS
-from iggtools.common.utils import tsprint, InputStream, OutputStream, retry, command, split, multiprocessing_map, multithreading_hashmap, multithreading_map, num_vcpu, parse_table, transpose, find_files, upload, upload_star, flatten, pythonpath
+from iggtools.common.utils import tsprint, InputStream, OutputStream, retry, command, split, multiprocessing_map, multithreading_hashmap, multithreading_map, num_vcpu, select_from_tsv, transpose, find_files, upload, upload_star, flatten, pythonpath
 from iggtools.models.uhgg import UHGG
 from iggtools.params import outputs
 
@@ -77,7 +77,7 @@ def parse_uclust(uclust_file, select_columns):
     # The uclust TSV file does not contain a header line.  So, we have to hardcode the schema here.  Then select specified columns.
     all_uclust_columns = ['type', 'cluster_id', 'size', 'pid', 'strand', 'skip1', 'skip2', 'skip3', 'gene_id', 'centroid_id']
     with InputStream(uclust_file) as ucf:
-        for r in parse_table(ucf, select_columns, all_uclust_columns):
+        for r in select_from_tsv(ucf, select_columns, all_uclust_columns):
             yield r
 
 

--- a/iggtools/subcommands/init.py
+++ b/iggtools/subcommands/init.py
@@ -1,5 +1,5 @@
 from iggtools.common.argparser import add_subcommand
-from iggtools.common.utils import tsprint, find_files, InputStream, OutputStream, parse_table
+from iggtools.common.utils import tsprint, find_files, InputStream, OutputStream, select_from_tsv
 from iggtools.params import inputs, outputs
 
 def init(args):
@@ -18,7 +18,7 @@ def init(args):
 
     id_remap = {}
     with InputStream(inputs.alt_species_ids) as ids:
-        for row in parse_table(ids, ["alt_species_id", "species_id"]):
+        for row in select_from_tsv(ids, selected_columns=["alt_species_id", "species_id"]):
             new_id, old_id = row
             id_remap[old_id] = new_id
 
@@ -29,7 +29,7 @@ def init(args):
         out.write("\t".join(target_columns) + "\n")
 
         with InputStream(inputs.genomes2species) as g2s:
-            for row in parse_table(g2s, ["MAG_code", "Species_id"]):
+            for row in select_from_tsv(g2s, selected_columns=["MAG_code", "Species_id"]):
                 genome, representative = row
                 species = id_remap[representative]
                 genome_is_representative = str(int(genome == representative))

--- a/iggtools/subcommands/midas_run_genes.py
+++ b/iggtools/subcommands/midas_run_genes.py
@@ -2,7 +2,7 @@ import json
 from collections import defaultdict
 
 from iggtools.common.argparser import add_subcommand
-from iggtools.common.utils import tsprint, num_physical_cores, command, InputStream, OutputStream, parse_table, multithreading_hashmap, download_reference, split
+from iggtools.common.utils import tsprint, num_physical_cores, command, InputStream, OutputStream, select_from_tsv, multithreading_hashmap, download_reference, split
 from iggtools.params import inputs, outputs
 
 
@@ -87,13 +87,12 @@ def build_pangenome_db(tempdir, centroids):
 
 def parse_species_profile(outdir):
     "Return map of species_id to coverage for the species present in the sample."
-    spfilename = f"{outdir}/species/species_profile.txt"
-    with InputStream(spfilename) as sppf:
-        return {species_id: float(species_coverage_str) for species_id, species_coverage_str in parse_table(sppf, ["species_id", "coverage"])}
+    with InputStream(f"{outdir}/species/species_profile.txt") as stream:
+        return dict(select_from_tsv(stream, {"species_id": str, "coverage": float}))
 
 
 def select_species(species_profile, coverage_threshold):
-    return {species_id: species_coverage for species_id, species_coverage in species_profile.items() if species_coverage > coverage_threshold}
+    return {species_id: species_coverage for species_id, species_coverage in species_profile.items() if species_coverage >= coverage_threshold}
 
 
 def pangenome_file(species_id, component):

--- a/iggtools/subcommands/midas_run_genes.py
+++ b/iggtools/subcommands/midas_run_genes.py
@@ -1,8 +1,9 @@
 import json
+import os
 from collections import defaultdict
 import numpy as np
 import Bio.SeqIO
-import pysam
+from pysam import AlignmentFile  # pylint: disable=no-name-in-module
 
 from iggtools.common.argparser import add_subcommand
 from iggtools.common.utils import tsprint, num_physical_cores, command, InputStream, OutputStream, select_from_tsv, multithreading_hashmap, download_reference, split
@@ -11,7 +12,11 @@ from iggtools.params import inputs, outputs
 
 DEFAULT_ALN_COV = 0.75
 DEFAULT_SPECIES_COVERAGE = 3.0
+DEFAULT_ALN_MAPID = 94.0
+DEFAULT_ALN_READQ = 20
+DEFAULT_ALN_MAPQ = 0
 
+DECIMALS = ".6f"
 
 def register_args(main_func):
     subparser = add_subcommand('midas_run_genes', main_func, help='metagenomic pan-genome profiling')
@@ -25,11 +30,6 @@ def register_args(main_func):
     subparser.add_argument('-2',
                            dest='r2',
                            help="FASTA/FASTQ file containing 2nd mate if using paired-end reads.")
-    subparser.add_argument('--mapid',
-                           dest='mapid',
-                           type=float,
-                           metavar="FLOAT",
-                           help=f"Discard reads with alignment identity < MAPID.  Values between 0-100 accepted.  By default gene-specific species-level cutoffs are used, as specifeid in {inputs.marker_genes_hmm_cutoffs}")
     subparser.add_argument('--max_reads',
                            dest='max_reads',
                            type=int,
@@ -56,11 +56,18 @@ def register_args(main_func):
                            type=float,
                            metavar="FLOAT",
                            help=f"Discard reads with alignment coverage < ALN_COV ({DEFAULT_ALN_COV}).  Values between 0-1 accepted.")
-    subparser.add_argument('--readq',
-                           dest='readq',
+    subparser.add_argument('--aln_readq',
+                           dest='aln_readq',
                            type=int,
                            metavar="INT",
-                           help=f"Discard reads with mean quality < READQ (20)")
+                           default=DEFAULT_ALN_READQ,
+                           help=f"Discard reads with mean quality < READQ ({DEFAULT_ALN_READQ})")
+    subparser.add_argument('--aln_mapid',
+                           dest='aln_mapid',
+                           type=float,
+                           metavar="FLOAT",
+                           default=DEFAULT_ALN_MAPID,
+                           help=f"Discard reads with alignment identity < MAPID.  Values between 0-100 accepted.  ({DEFAULT_ALN_MAPID})")
     subparser.add_argument('--aln_speed',
                            type=str,
                            dest='aln_speed',
@@ -82,10 +89,14 @@ def register_args(main_func):
 
 
 def build_pangenome_db(tempdir, centroids):
+    if all(os.path.exists(f"{tempdir}/pangenomes.{ext}") for ext in ["1.bt2", "2.bt2", "3.bt2", "4.bt2", "rev.1.bt2", "rev.2.bt2"]):
+        tsprint("Skipping bowtie2-build as database files appear to exist.")
+        return
+    command(f"rm -f {tempdir}/pangenomes.fa")
     command(f"touch {tempdir}/pangenomes.fa")
     for files in split(centroids.values(), 20):  # keep "cat" commands short
         command("cat " + " ".join(files) + f" >> {tempdir}/pangenomes.fa")
-    command(f"bowtie2-build --threads {num_physical_cores} {tempdir}/pangenomes.fa {tempdir}/pangenomes")
+    command(f"bowtie2-build --threads {num_physical_cores} {tempdir}/pangenomes.fa {tempdir}/pangenomes > {tempdir}/bowtie2-build.log")
 
 
 def parse_species_profile(outdir):
@@ -106,6 +117,10 @@ def pangenome_file(species_id, component):
 def pangenome_align(args, tempdir):
     """ Use Bowtie2 to map reads to all specified genome species """
 
+    if args.debug and os.path.exists(f"{tempdir}/pangenomes.bam"):
+        tsprint(f"Skipping alignment in debug mode as temporary data exists: {tempdir}/pangenomes.bam")
+        return
+
     max_reads = f"-u {args.max_reads}" if args.max_reads else ""
     aln_mode = "local" if args.aln_mode == "local" else "end-to-end"
     aln_speed = args.aln_speed if aln_mode == "end_to_end" else args.aln_speed + "-local"
@@ -119,7 +134,7 @@ def pangenome_align(args, tempdir):
         r1 = f"-U {args.r1}"
 
     try:
-        command(f"set -o pipefail;  bowtie2 --no-unal -x {tempdir}/pangenomes {max_reads} --{aln_mode} --{aln_speed} --threads {num_physical_cores} -q {r1} {r2} | samtools view --threads {num_physical_cores} -b - > {tempdir}/pangenomes.bam")
+        command(f"set -o pipefail; bowtie2 --no-unal -x {tempdir}/pangenomes {max_reads} --{aln_mode} --{aln_speed} --threads {num_physical_cores} -q {r1} {r2} | samtools view --threads {num_physical_cores} -b - > {tempdir}/pangenomes.bam")
     except:
         command(f"rm -f {tempdir}/pangenomes.bam")
         raise
@@ -144,51 +159,55 @@ def keep_read(aln, min_pid, min_readq, min_mapq, min_aln_cov):
 
 
 def count_mapped_bp(args, tempdir, genes):
-    """ Count number of bp mapped to each gene across pangenomes """
-    bam_path = f"{tempdir}/genes/temp/pangenomes.bam'"
-    bamfile = pysam.AlignmentFile(bam_path, "rb")
+    """ Count number of bp mapped to each gene across pangenomes.  Return number covered genes and average gene depth per species.  Result contains only covered species, but being a defaultdict, would yield 0 for any uncovered species, which is appropriate. """
+    bam_path = f"{tempdir}/pangenomes.bam"
+    bamfile = AlignmentFile(bam_path, "rb")
+    covered_genes = {}
 
     # loop over alignments, sum values per gene
     for aln in bamfile.fetch(until_eof=True):
         gene_id = bamfile.getrname(aln.reference_id)
         gene = genes[gene_id]
         gene["aligned_reads"] += 1
-        if keep_read(aln, args.mapid, args.readq, args.mapq, args.aln_cov):
+        if keep_read(aln, args.aln_mapid, args.aln_readq, DEFAULT_ALN_MAPQ, args.aln_cov):
             gene["mapped_reads"] += 1
             gene["depth"] += len(aln.query_alignment_sequence) / float(gene["length"])
+            covered_genes[gene_id] = gene
 
     tsprint("Pangenome count_mapped_bp:  total aligned reads: %s" % sum(g["aligned_reads"] for g in genes.values()))
     tsprint("Pangenome count_mapped_bp:  total mapped reads: %s" % sum(g["mapped_reads"] for g in genes.values()))
 
-    # Group gene depths by species
-    gene_depths = defaultdict(list)
-    for g in genes.values():
-        gene_depths[g["species_id"]].append(g["depth"])
+    # Filter to genes with non-zero depth, then group by species
+    nonzero_gene_depths = defaultdict(list)
+    for g in covered_genes.values():
+        gene_depth = g["depth"]
+        if gene_depth > 0:  # This should always pass, because ags.aln_cov is always >0.
+            species_id = g["species_id"]
+            nonzero_gene_depths[species_id].append(gene_depth)
 
-    # loop over species, compute summaries
-    num_covered_genes = {}
-    mean_coverage = {}
-    for species_id, depths in gene_depths.items():
-        non_zero_depths = [d for d in depths if d > 0]
-        num_covered_genes = len(non_zero_depths)
-        mean_coverage[species_id] = np.mean(non_zero_depths) if non_zero_depths else 0
-        num_covered_genes[species_id] = num_covered_genes
+    # Compute number of covered genes per species, and average gene depth.
+    num_covered_genes = defaultdict(int)
+    mean_coverage = defaultdict(float)
+    for species_id, non_zero_depths in nonzero_gene_depths.items():
+        num_covered_genes[species_id] = len(non_zero_depths)
+        mean_coverage[species_id] = np.mean(non_zero_depths)
 
-    return num_covered_genes, mean_coverage
+    return num_covered_genes, mean_coverage, covered_genes
 
 
-def normalize(genes):
-    """ Count number of bp mapped to each marker gene """
+def normalize(genes, covered_genes, markers):
+    """ Normalize gene depth by median marker depth, to infer gene copy count.  Return median marker coverage for each covered species in a defaultdict, so that accessing an uncovered species would appropriately yield 0. """
     # compute marker depth
     species_markers = defaultdict(lambda: defaultdict(int))
-    for gene in genes.values():
-        gene_marker_id = gene["marker_id"]
-        if gene_marker_id:
-            species_markers[gene["species_id"]][gene_marker_id] += gene["depth"]
-    # compute median marker depth
-    species_markers_coverage = {species_id: np.median(marker_depths) for species_id, marker_depths in species_markers.items()}
-    # normalize genes by median marker depth
-    for gene in genes.values():
+    for gene_id, marker_id in markers:
+        g = genes[gene_id]
+        species_markers[g["species_id"]][marker_id] += g["depth"]
+    # compute median marker depth for each species
+    species_markers_coverage = defaultdict(float)
+    for species_id, marker_depths in species_markers.items():
+        species_markers_coverage[species_id] = np.median(list(marker_depths.values()))   # np.median doesn't take iterators
+    # infer copy count for each covered gene
+    for gene in covered_genes.values():
         species_id = gene["species_id"]
         marker_coverage = species_markers_coverage[species_id]
         if marker_coverage > 0:
@@ -196,40 +215,49 @@ def normalize(genes):
     return species_markers_coverage
 
 
-def write_results(tempdir, species, num_covered_genes, markers_coverage, mean_coverage):
+def write_results(tempdir, species, num_covered_genes, species_markers_coverage, species_mean_coverage):
+    if not os.path.exists(f"{tempdir}/genes/output"):
+        command(f"mkdir -p {tempdir}/genes/output")
     # open outfiles for each species_id
     header = ['gene_id', 'count_reads', 'coverage', 'copy_number']
-    for species_id, species_genes in species:
-        path = f"{tempdir}/genes/output/{species_id}.genes.gz"
+    for species_id, species_genes in species.items():
+        path = f"{tempdir}/genes/output/{species_id}.genes.lz4"
         with OutputStream(path) as sp_out:
             sp_out.write('\t'.join(header) + '\n')
             for gene_id, gene in species_genes.items():
-                values = [gene_id, gene["mapped_reads"], gene["depth"], gene["copies"]]
-                sp_out.write('\t'.join([str(v) for v in values]) + '\n')
+                if gene["depth"] == 0:
+                    # Sparse by default here.  You can get the pangenome_size from the summary file, emitted below.
+                    continue
+                # TODO perhaps truncate precision a bit...
+                values = [gene_id, str(gene["mapped_reads"]), format(gene["depth"], DECIMALS), format(gene["copies"], DECIMALS)]
+                sp_out.write('\t'.join(values) + '\n')
     # summary stats
     header = ['species_id', 'pangenome_size', 'covered_genes', 'fraction_covered', 'mean_coverage', 'marker_coverage', 'aligned_reads', 'mapped_reads']
     path = f"{tempdir}/genes/summary.txt"
     with OutputStream(path) as file:
         file.write('\t'.join(header) + '\n')
         for species_id, species_genes in species.items():
-            aligned_reads = sum(g["algined_reads"] for g in species_genes)
-            mapped_reads = sum(g["mapped_reads"] for g in species_genes)
+            # No sparsity here -- should be extremely rare for a species row to be all 0.
+            aligned_reads = sum(g["aligned_reads"] for g in species_genes.values())
+            mapped_reads = sum(g["mapped_reads"] for g in species_genes.values())
             pangenome_size = len(species_genes)
-            values = [species_id, pangenome_size, num_covered_genes[species_id], num_covered_genes[species_id] / pangenome_size, mean_coverage[species_id], markers_coverage[species_id], aligned_reads, mapped_reads]
-            file.write('\t'.join(str(v) for v in values) + '\n')
-
-
-def pangenome_coverage(args, tempdir, species, genes):
-    """ Compute coverage of pangenome for species_id and write results to disk """
-    num_covered_genes, species_mean_coverage = count_mapped_bp(args, tempdir, genes)
-    species_markers_coverage = normalize(genes)
-    write_results(tempdir, species, num_covered_genes, species_markers_coverage, species_mean_coverage)
+            values = [
+                species_id,
+                str(pangenome_size),
+                str(num_covered_genes[species_id]),
+                format(num_covered_genes[species_id] / pangenome_size, DECIMALS),
+                format(species_mean_coverage[species_id], DECIMALS),
+                format(species_markers_coverage[species_id], DECIMALS),
+                str(aligned_reads),
+                str(mapped_reads)
+            ]
+            file.write('\t'.join(values) + '\n')
 
 
 def scan_centroids(centroids_files):
     species = defaultdict(dict)
     genes = {}
-    for species_id, centroid_filename in centroids_files:
+    for species_id, centroid_filename in centroids_files.items():
         with InputStream(centroid_filename) as file:
             for centroid in Bio.SeqIO.parse(file, 'fasta'):
                 centroid_gene_id = centroid.id
@@ -244,34 +272,58 @@ def scan_centroids(centroids_files):
                 }
                 species[species_id][centroid_gene_id] = centroid_gene
                 genes[centroid_gene_id] = centroid_gene
+
     return species, genes
+
+
+def scan_markers(genes, marker_genes_map_file):
+    markers = []
+    with InputStream(marker_genes_map_file) as mg_map:
+        for gene_id, marker_id in select_from_tsv(mg_map, ["gene_id", "marker_id"], {"species_id": str, "genome_id": str, "gene_id": str, "gene_len": int, "marker_id": str}):
+            if gene_id in genes:
+                markers.append((gene_id, marker_id))
+    return markers
 
 
 def midas_run_genes(args):
 
     tempdir = f"{args.outdir}/genes/temp_sc{args.species_cov}"
 
-    command(f"rm -rf {tempdir}")
-    command(f"mkdir -p {tempdir}")
+    if args.debug and os.path.exists(tempdir):
+        tsprint(f"INFO:  Reusing existing temp data in {tempdir} according to --debug flag.")
+    else:
+        command(f"rm -rf {tempdir}")
+        command(f"mkdir -p {tempdir}")
 
-    # Species profile must exist, it's output by run_midas_species
-    full_species_profile = parse_species_profile(args.outdir)
+    try:
+        # The full species profile must exist -- it is output by run_midas_species.
+        # Restrict to species above requested coverage.
+        full_species_profile = parse_species_profile(args.outdir)
+        species_profile = select_species(full_species_profile, args.species_cov)
 
-    species_profile = select_species(full_species_profile, args.species_cov)
+        def download_centroid(species_id):
+            return download_reference(pangenome_file(species_id, "centroids.ffn.lz4"), f"{tempdir}/{species_id}")  # TODO colocate samples to overlap reference downloads
 
-    def download_centroid(species_id):
-        return download_reference(pangenome_file(species_id, "centroids.ffn.lz4"), f"{tempdir}/{species_id}")  # TODO colocate samples to overlap reference downloads
+        # Download centroids.ffn for every species in the restricted species profile.
+        centroids_files = multithreading_hashmap(download_centroid, species_profile.keys(), num_threads=20)
 
-    # Download centroids.ffn for every species
-    centroids_files = multithreading_hashmap(download_centroid, species_profile.keys(), num_threads=20)
+        # Perhaps avoid this giant conglomerated file, fetching instead submaps for each species.
+        # Also colocate/cache/download in master for multiple slave subcommand invocations.
+        marker_genes_map = "s3://microbiome-igg/2.0/marker_genes/phyeco/phyeco.map.lz4"
 
-    build_pangenome_db(tempdir, centroids_files)
+        build_pangenome_db(tempdir, centroids_files)
+        pangenome_align(args, tempdir)
 
-    pangenome_align(args, tempdir)
-
-    species, genes = scan_centroids(centroids_files)
-
-    pangenome_coverage(args, tempdir, species, genes)
+        # Compute coverage of pangenome for each present species and write results to disk
+        species, genes = scan_centroids(centroids_files)
+        num_covered_genes, species_mean_coverage, covered_genes = count_mapped_bp(args, tempdir, genes)
+        markers = scan_markers(genes, marker_genes_map)
+        species_markers_coverage = normalize(genes, covered_genes, markers)
+        write_results(tempdir, species, num_covered_genes, species_markers_coverage, species_mean_coverage)
+    except:
+        if not args.debug:
+            tsprint("Deleting untrustworthy outputs due to error.  Specify --debug flag to keep.")
+            command(f"rm -rf {tempdir}", check=False)
 
 
 @register_args

--- a/iggtools/subcommands/midas_run_genes.py
+++ b/iggtools/subcommands/midas_run_genes.py
@@ -1,0 +1,151 @@
+import json
+from collections import defaultdict
+
+from iggtools.common.argparser import add_subcommand
+from iggtools.common.utils import tsprint, num_physical_cores, command, InputStream, OutputStream, parse_table, multithreading_hashmap, download_reference, split
+from iggtools.params import inputs, outputs
+
+
+DEFAULT_ALN_COV = 0.75
+DEFAULT_SPECIES_COVERAGE = 3.0
+
+
+def register_args(main_func):
+    subparser = add_subcommand('midas_run_genes', main_func, help='metagenomic pan-genome profiling')
+    subparser.add_argument('outdir',
+                           type=str,
+                           help="""Path to directory to store results.  Name should correspond to unique sample identifier.""")
+    subparser.add_argument('-1',
+                           dest='r1',
+                           required=True,
+                           help="FASTA/FASTQ file containing 1st mate if using paired-end reads.  Otherwise FASTA/FASTQ containing unpaired reads.")
+    subparser.add_argument('-2',
+                           dest='r2',
+                           help="FASTA/FASTQ file containing 2nd mate if using paired-end reads.")
+    subparser.add_argument('--mapid',
+                           dest='mapid',
+                           type=float,
+                           metavar="FLOAT",
+                           help=f"Discard reads with alignment identity < MAPID.  Values between 0-100 accepted.  By default gene-specific species-level cutoffs are used, as specifeid in {inputs.marker_genes_hmm_cutoffs}")
+    subparser.add_argument('--max_reads',
+                           dest='max_reads',
+                           type=int,
+                           metavar="INT",
+                           help=f"Number of reads to use from input file(s).  (All)")
+    subparser.add_argument('--species_cov',
+                           type=float,
+                           dest='species_cov',
+                           metavar='FLOAT',
+                           default=DEFAULT_SPECIES_COVERAGE,
+                           help=f"Include species with >X coverage ({DEFAULT_SPECIES_COVERAGE})")
+    if False:
+        # This is unused.
+        subparser.add_argument('--species_topn',
+                               type=int,
+                               dest='species_topn',
+                               metavar='INT',
+                               help='Include top N most abundant species')
+
+    #  Alignment flags (bowtie, or postprocessing)
+    subparser.add_argument('--aln_cov',
+                           dest='aln_cov',
+                           default=DEFAULT_ALN_COV,
+                           type=float,
+                           metavar="FLOAT",
+                           help=f"Discard reads with alignment coverage < ALN_COV ({DEFAULT_ALN_COV}).  Values between 0-1 accepted.")
+    subparser.add_argument('--readq',
+                           dest='readq',
+                           type=int,
+                           metavar="INT",
+                           help=f"Discard reads with mean quality < READQ (20)")
+    subparser.add_argument('--aln_speed',
+                           type=str,
+                           dest='aln_speed',
+                           default='very-sensitive',
+                           choices=['very-fast', 'fast', 'sensitive', 'very-sensitive'],
+                           help='Alignment speed/sensitivity (very-sensitive)')
+    subparser.add_argument('--aln_mode',
+                           type=str,
+                           dest='aln_mode',
+                           default='local',
+                           choices=['local', 'global'],
+                           help='Global/local read alignment (local)')
+    subparser.add_argument('--aln_interleaved',
+                           action='store_true',
+                           default=False,
+                           help='FASTA/FASTQ file in -1 are paired and contain forward AND reverse reads')
+
+    return main_func
+
+
+def build_pangenome_db(tempdir, centroids):
+    command(f"touch {tempdir}/pangenomes.fa")
+    for files in split(centroids.values(), 20):  # keep "cat" commands short
+        command("cat " + " ".join(files) + f" >> {tempdir}/pangenomes.fa")
+    command(f"bowtie2-build --threads {num_physical_cores} {tempdir}/pangenomes.fa {tempdir}/pangenomes")
+
+
+def parse_species_profile(outdir):
+    "Return map of species_id to coverage for the species present in the sample."
+    spfilename = f"{outdir}/species/species_profile.txt"
+    with InputStream(spfilename) as sppf:
+        return {species_id: float(species_coverage_str) for species_id, species_coverage_str in parse_table(sppf, ["species_id", "coverage"])}
+
+
+def select_species(species_profile, coverage_threshold):
+    return {species_id: species_coverage for species_id, species_coverage in species_profile.items() if species_coverage > coverage_threshold}
+
+
+def pangenome_file(species_id, component):
+    # s3://microbiome-igg/2.0/pangenomes/GUT_GENOMEDDDDDD/{genes.ffn, centroids.ffn, gene_info.txt}
+    return f"{outputs.pangenomes}/{species_id}/{component}"
+
+
+def pangenome_align(args, tempdir):
+    """ Use Bowtie2 to map reads to all specified genome species """
+
+    max_reads = f"-u {args.max_reads}" if args.max_reads else ""
+    local_vs_global = "--local" if args.aln_mode == "local" else ""
+    r2 = ""
+    if args.r2:
+        r1 = f"-1 {args.r1}"
+        r2 = f"-2 {args.r2}"
+    elif args.aln_interleaved:
+        r1 = f"--interleaved {args.r1}"
+    else:
+        r1 = f"-U {args.r1}"
+
+    try:
+        command(f"set -o pipefail;  bowtie2 --no-unal -x {tempdir}/pangenomes {max_reads} --{args.aln_speed} {local_vs_global} --threads {num_physical_cores} -q {r1} {r2} | samtools view --threads {num_physical_cores} -b - > {tempdir}/pangenomes.bam")
+    except:
+        command(f"rm -f {tempdir}/pangenomes.bam")
+        raise
+
+
+def midas_run_genes(args):
+
+    tempdir = f"{args.outdir}/genes/temp_sc{args.species_cov}"
+
+    command(f"rm -rf {tempdir}")
+    command(f"mkdir -p {tempdir}")
+
+    # Species profile must exist, it's output by run_midas_species
+    full_species_profile = parse_species_profile(args.outdir)
+
+    species_profile = select_species(full_species_profile, args.species_cov)
+
+    def download_centroid(species_id):
+        return download_reference(pangenome_file(species_id, "centroids.ffn.lz4"), f"{tempdir}/{species_id}")  # TODO colocate samples to overlap reference downloads
+
+    # Download centroids.ffn for every species
+    centroids = multithreading_hashmap(download_centroid, species_profile.keys(), num_threads=20)
+
+    build_pangenome_db(tempdir, centroids)
+
+    pangenome_align(args, tempdir)
+
+
+@register_args
+def main(args):
+    tsprint(f"Doing important work in subcommand {args.subcommand} with args\n{json.dumps(vars(args), indent=4)}")
+    midas_run_genes(args)

--- a/iggtools/subcommands/midas_run_species.py
+++ b/iggtools/subcommands/midas_run_species.py
@@ -5,7 +5,7 @@ from itertools import chain
 import numpy as np
 
 from iggtools.common.argparser import add_subcommand
-from iggtools.common.utils import tsprint, num_physical_cores, command, InputStream, OutputStream, parse_table_as_rowdicts, parse_table, multithreading_map, download_reference, TimedSection
+from iggtools.common.utils import tsprint, num_physical_cores, command, InputStream, OutputStream, select_from_tsv, multithreading_map, download_reference, TimedSection
 from iggtools.models.uhgg import UHGG
 from iggtools import params
 
@@ -120,14 +120,20 @@ def map_reads_hsblast(tempdir, r1, r2, word_size, markers_db, max_reads):
     return m8_file
 
 
-def parse_blast(inpath):
-    """ Yield formatted record from BLAST m8 file """
-    # TODO: Bring schema parser from idseq-dag.
-    BLAST_COLUMN_TYPES = [str, str, float, int, float, float, float, float, float, float, float, float, int, int]
-    BLAST_COLUMNS = ['query', 'target', 'pid', 'aln', 'mis', 'gaps', 'qstart', 'qend', 'tstart', 'tend', 'evalue', 'score']
-    for line in open(inpath):
-        values = line.rstrip().split()
-        yield dict((field, format(value)) for field, format, value in zip(BLAST_COLUMNS, BLAST_COLUMN_TYPES, values))
+BLAST_M8_SCHEMA = {
+    'query': str,
+    'target': str,
+    'pid': float,
+    'aln': int,
+    'mis': float,
+    'gaps': float,
+    'qstart': float,
+    'qend': float,
+    'tstart': float,
+    'tend': float,
+    'evalue': float,
+    'score': float,
+}
 
 
 def deconstruct_queryid(rid):
@@ -149,22 +155,23 @@ def find_best_hits(args, marker_info, m8_file, marker_cutoffs):
     """ Find top scoring alignment for each read """
     best_hits = {}
     i = 0
-    for aln in parse_blast(m8_file):
-        i += 1
-        cutoff = args.mapid
-        if cutoff == None:
-            marker_id = marker_info[aln['target']]['marker_id'] # get gene family from marker_info
-            cutoff = marker_cutoffs[marker_id]
-        if aln['pid'] < cutoff: # does not meet marker cutoff
-            continue
-        if query_coverage(aln) < args.aln_cov: # filter local alignments
-            continue
-        if aln['query'] not in best_hits: # record aln
-            best_hits[aln['query']] = [aln]
-        elif best_hits[aln['query']][0]['score'] == aln['score']: # add aln
-            best_hits[aln['query']] += [aln]
-        elif best_hits[aln['query']][0]['score'] < aln['score']: # update aln
-            best_hits[aln['query']] = [aln]
+    with InputStream(m8_file) as m8_stream:
+        for aln in select_from_tsv(m8_stream, schema=BLAST_M8_SCHEMA, result_structure=dict):
+            i += 1
+            cutoff = args.mapid
+            if cutoff == None:
+                marker_id = marker_info[aln['target']]['marker_id'] # get gene family from marker_info
+                cutoff = marker_cutoffs[marker_id]
+            if aln['pid'] < cutoff: # does not meet marker cutoff
+                continue
+            if query_coverage(aln) < args.aln_cov: # filter local alignments
+                continue
+            if aln['query'] not in best_hits: # record aln
+                best_hits[aln['query']] = [aln]
+            elif best_hits[aln['query']][0]['score'] == aln['score']: # add aln
+                best_hits[aln['query']] += [aln]
+            elif best_hits[aln['query']][0]['score'] < aln['score']: # update aln
+                best_hits[aln['query']] = [aln]
     tsprint(f"  total alignments: {i}")
     return list(best_hits.values())
 
@@ -205,8 +212,8 @@ def assign_non_unique(alns, unique_alns, marker_info):
 
 def read_marker_info_repgenomes(map_file):
     columns = ["species_id", "genome_id", "gene_id", "gene_length", "marker_id"]
-    with InputStream(map_file) as impf:
-        return {r['gene_id']: r for r in parse_table_as_rowdicts(impf, columns, columns)}
+    with InputStream(map_file) as map_file_stream:
+        return {r['gene_id']: r for r in select_from_tsv(map_file_stream, schema=columns, result_structure=dict)}
 
 
 def sum_marker_gene_lengths(marker_info):
@@ -271,7 +278,7 @@ def midas_run_species(args):
         m8_file = map_reads_hsblast(tempdir, args.r1, args.r2, args.word_size, markers_db_files[0], args.max_reads)
 
     with InputStream(params.inputs.marker_genes_hmm_cutoffs) as cutoff_params:
-        marker_cutoffs = {marker_id: float(marker_cutoff_str) for marker_id, marker_cutoff_str in parse_table(cutoff_params, ["marker_id", "marker_cutoff"])}
+        marker_cutoffs = dict(select_from_tsv(cutoff_params, selected_columns={"marker_id": str, "marker_cutoff": float}))
 
     with TimedSection("classifying reads"):
         best_hits = find_best_hits(args, marker_info, m8_file, marker_cutoffs)

--- a/iggtools/subcommands/midas_run_species.py
+++ b/iggtools/subcommands/midas_run_species.py
@@ -241,7 +241,7 @@ def normalize_counts(species_alns, total_gene_length):
 
 def write_abundance(outdir, species_abundance):
     """ Write species results to specified output file """
-    outpath = f"{outdir}/species/species_profile.txt"
+    outpath = f"{outdir}/species/species_profile.txt"  # TODO:  Share this across midas_run_ steps
     with OutputStream(outpath) as outfile:
         fields = ['species_id', 'count_reads', 'coverage', 'relative_abundance']
         outfile.write('\t'.join(fields) + '\n')


### PR DESCRIPTION
Seems to work for a small test sample.

Result summary:
```
cat test/genes/temp_sc1.0/genes/summary.txt

species_id	pangenome_size	covered_genes	fraction_covered	mean_coverage	marker_coverage	aligned_reads	mapped_reads
100479	13059	7287	0.558006	1.002046	1.620626	67131	50579
102772	6268	5201	0.829770	1.844259	0.498774	85784	60390
100639	20177	7962	0.394608	0.749461	0.233025	54205	39327
```

Gene coverage for one species:
```
lz4 -dc test/genes/temp_sc1.0/genes/output/100639.genes.lz4 | less

gene_id count_reads     coverage        copy_number
UHGG027360_01726        7       0.090535        0.388521
UHGG024293_01468        9       0.116692        0.500773
UHGG044014_00957        5       0.062763        0.269342
UHGG157460_01574        28      0.356675        1.530633
UHGG019205_00569        8       0.104993        0.450566
UHGG164220_00251        13      0.165664        0.710931
UHGG019292_00485        4       0.057037        0.244770
UHGG011477_01110        2       0.028571        0.122611
UHGG027372_00317        20      0.289261        1.241332
UHGG157447_01509        15      0.217463        0.933219
...
```

Command line and execution log.
```
p3 -m iggtools midas_run_genes -1 head1p5mil.fastq --species_cov 1.0 test

1577923013.6:  Doing important work in subcommand midas_run_genes with args
1577923013.6:  {
1577923013.6:      "subcommand": "midas_run_genes",
1577923013.6:      "force": false,
1577923013.6:      "debug": false,
1577923013.6:      "zzz_slave_mode": false,
1577923013.6:      "batch_branch": "master",
1577923013.6:      "batch_memory": 378880,
1577923013.6:      "batch_vcpus": 48,
1577923013.6:      "batch_queue": "pairani",
1577923013.6:      "batch_ecr_image": "iggtools",
1577923013.6:      "outdir": "test",
1577923013.6:      "r1": "head1p5mil.fastq",
1577923013.6:      "r2": null,
1577923013.6:      "max_reads": null,
1577923013.6:      "species_cov": 1.0,
1577923013.6:      "aln_cov": 0.75,
1577923013.6:      "aln_readq": 20,
1577923013.6:      "aln_mapid": 94.0,
1577923013.6:      "aln_speed": "very-sensitive",
1577923013.6:      "aln_mode": "local",
1577923013.6:      "aln_interleaved": false
1577923013.6:  }
1577923013.6:  'rm -rf test/genes/temp_sc1.0'
1577923013.6:  'mkdir -p test/genes/temp_sc1.0'
1577923013.6:  'cat test/species/species_profile.txt'
1577923013.6:  'mkdir -p test/genes/temp_sc1.0/100479'
1577923013.6:  'mkdir -p test/genes/temp_sc1.0/102772'
1577923013.6:  'mkdir -p test/genes/temp_sc1.0/100639'
1577923013.6:  'aws s3 cp --only-show-errors s3://microbiome-igg/2.0/pangenomes/100479/centroids.ffn.lz4 - | lz4 -dc > test/genes/temp_sc1.0/100479/centroids.ffn'
1577923013.6:  'aws s3 cp --only-show-errors s3://microbiome-igg/2.0/pangenomes/102772/centroids.ffn.lz4 - | lz4 -dc > test/genes/temp_sc1.0/102772/centroids.ffn'
1577923013.6:  'aws s3 cp --only-show-errors s3://microbiome-igg/2.0/pangenomes/100639/centroids.ffn.lz4 - | lz4 -dc > test/genes/temp_sc1.0/100639/centroids.ffn'
1577923014.1:  'rm -f test/genes/temp_sc1.0/pangenomes.fa'
1577923014.1:  'touch test/genes/temp_sc1.0/pangenomes.fa'
1577923014.1:  'cat test/genes/temp_sc1.0/100479/centroids.ffn test/genes/temp_sc1.0/102772/centroids.ffn test/genes/temp_sc1.0/100639/centroids.ffn >> test/genes/temp_sc1.0/pangenomes.fa'
1577923014.2:  'bowtie2-build --threads 16 test/genes/temp_sc1.0/pangenomes.fa test/genes/temp_sc1.0/pangenomes > test/genes/temp_sc1.0/bowtie2-build.log'
Building a SMALL index
1577923032.7:  ' bowtie2 --no-unal -x test/genes/temp_sc1.0/pangenomes  --local --very-sensitive-local --threads 16 -q -U head1p5mil.fastq  | samtools view --threads 16 -b - > test/genes/temp_sc1.0/pangenomes.bam'
1500000 reads; of these:
  1500000 (100.00%) were unpaired; of these:
    1292880 (86.19%) aligned 0 times
    73176 (4.88%) aligned exactly 1 time
    133944 (8.93%) aligned >1 times
13.81% overall alignment rate
1577923040.1:  'cat test/genes/temp_sc1.0/100479/centroids.ffn'
1577923040.2:  'cat test/genes/temp_sc1.0/102772/centroids.ffn'
1577923040.3:  'cat test/genes/temp_sc1.0/100639/centroids.ffn'
1577923044.3:  Pangenome count_mapped_bp:  total aligned reads: 207120
1577923044.3:  Pangenome count_mapped_bp:  total mapped reads: 150296
1577923044.7:  'aws s3 --quiet cp s3://microbiome-igg/2.0/marker_genes/phyeco/phyeco.map.lz4 - | lz4 -dc'
1577923045.2:  'mkdir -p test/genes/temp_sc1.0/genes/output'
1577923045.2:  'lz4 -c | cat > test/genes/temp_sc1.0/genes/output/100479.genes.lz4'
1577923045.2:  'lz4 -c | cat > test/genes/temp_sc1.0/genes/output/102772.genes.lz4'
1577923045.2:  'lz4 -c | cat > test/genes/temp_sc1.0/genes/output/100639.genes.lz4'
1577923045.2:  'cat > test/genes/temp_sc1.0/genes/summary.txt'
```
