### PR TITLE
Make `--sparse` act like a traditional option flag for run_midas_snps subcommand.

### DIFF
--- a/iggtools/subcommands/midas_run_snps.py
+++ b/iggtools/subcommands/midas_run_snps.py
@@ -126,8 +126,7 @@ def register_args(main_func):
                                dest='aln_adjust_mq',
                                default=False,
                                help='Adjust MAPQ (False)')
-    subparser.add_argument('--sparse',
-                           dest='sparse',
+    subparser.add_argument('--sparse', action='store_true',
                            default=False,
                            help=f"Omit zero rows from output.")
     return main_func


### PR DESCRIPTION
Using the argparse module, flags can be set to act as binary settings using the `action='set_true'` parameter.  Doing so for `--sparse` means that you don't need to pass an additional argument when using the flag.

old:
```
iggtools midas_run_snps -1 <r1> -2 <r2> --sparse 1 <dir>
```

new:
```
iggtools midas_run_snps -1 <r1> -2 <r2> --sparse <dir>
```
