### PR TITLE
add gene annotation to midas_merge_snps

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -21,3 +21,4 @@ dependencies:
  - r-tidyverse
  - lz4
  - art
+ - gffutils

--- a/iggtools/__init__.py
+++ b/iggtools/__init__.py
@@ -3,4 +3,4 @@
 import sys
 assert sys.version_info >= (3, 7), "Python version >= 3.7 is required."
 
-version = "0.14"
+version = "0.15"

--- a/iggtools/__main__.py
+++ b/iggtools/__main__.py
@@ -9,7 +9,7 @@
 # with their own set of command line arguments and subcommand help text -- aside from
 # the shared arguments and shared help text defined in iggtools.common.argparser.
 #
-from iggtools.subcommands import aws_batch_init, aws_batch_submit, init, build_pangenome, import_uhgg, annotate_genes, build_marker_genes, collate_repgenome_markers, midas_run_species, midas_run_genes, midas_run_snps, midas_merge_species, midas_merge_snps, midas_merge_genes, build_bowtie2_indexes # pylint: disable=unused-import
+from iggtools.subcommands import aws_batch_init, aws_batch_submit, init, build_pangenome, import_uhgg, annotate_genes, build_marker_genes, collate_repgenome_markers, midas_run_species, midas_run_genes, midas_run_snps, midas_merge_species, midas_merge_snps, midas_merge_genes, build_bowtie2_indexes, build_gene_features # pylint: disable=unused-import
 from iggtools.common.argparser import parse_args
 
 

--- a/iggtools/models/uhgg.py
+++ b/iggtools/models/uhgg.py
@@ -94,6 +94,15 @@ class MIDAS_IGGDB: # pylint: disable=too-few-public-methods
                 if filetype == "marker_centroids":
                     s3_file = self.get_target_layout("marker_centroids", True, "", species_id)
                     dest_file = self.get_target_layout("marker_centroids", False, "", species_id)
+                if filetype == "gene_feature":
+                    s3_file = self.get_target_layout("annotation_file", True, "genes", species_id, self.uhgg.representatives[species_id])
+                    dest_file = self.get_target_layout("annotation_file", False, "genes", species_id, self.uhgg.representatives[species_id])
+                if filetype == "gene_seq":
+                    s3_file = self.get_target_layout("annotation_file", True, "ffn", species_id, self.uhgg.representatives[species_id])
+                    dest_file = self.get_target_layout("annotation_file", False, "ffn", species_id, self.uhgg.representatives[species_id])
+                if filetype == "prokka_genome":
+                    s3_file = self.get_target_layout("annotation_file", True, "fna", species_id, self.uhgg.representatives[species_id])
+                    dest_file = self.get_target_layout("annotation_file", False, "fna", species_id, self.uhgg.representatives[species_id])
                 args_list.append((s3_file, dest_file))
 
             _fetched_files = multithreading_map(_fetch_file_from_s3, args_list, num_threads=self.num_cores)

--- a/iggtools/params/schemas.py
+++ b/iggtools/params/schemas.py
@@ -125,7 +125,12 @@ snps_info_schema = {
     "sc_C": int,
     "sc_G": int,
     "sc_T": int,
+    "locus_type": str,
+    "gene_id": str,
+    "site_type": str,
+    "amino_acids": str
 }
+
 
 ## merge_midas_genes
 DEFAULT_SAMPLE_DEPTH = 1.0

--- a/iggtools/params/schemas.py
+++ b/iggtools/params/schemas.py
@@ -183,3 +183,14 @@ def fetch_schema_by_dbtype(dbtype):
 
 def format_data(x):
     return format(x, DECIMALS) if isinstance(x, float) else str(x)
+
+
+
+genes_feature_schema = {
+    "gene_id": str,
+    "contig_id": str,
+    "start": int,
+    "end": int,
+    "strand": str,
+    "gene_type": str,
+}

--- a/iggtools/subcommands/__init__.py
+++ b/iggtools/subcommands/__init__.py
@@ -3,4 +3,4 @@ __all__ = ["aws_batch_init", "aws_batch_submit", "init", "build_pangenome", "imp
             "annotate_genes", "build_marker_genes", "collate_repgenome_markers", \
             "midas_run_species", "midas_run_genes", "midas_run_snps", \
             "midas_merge_species", "midas_merge_snps", "midas_merge_genes", \
-            "build_bowtie2_indexes", "example_subcommand"]
+            "build_bowtie2_indexes", "build_gene_features", "example_subcommand"]

--- a/iggtools/subcommands/build_gene_features.py
+++ b/iggtools/subcommands/build_gene_features.py
@@ -1,0 +1,166 @@
+import os
+import sys
+from multiprocessing import Semaphore
+from iggtools.common.argparser import add_subcommand, SUPPRESS
+from iggtools.common.utils import tsprint, retry, command, multithreading_map, find_files, upload, pythonpath, upload_star, download_reference, InputStream, OutputStream
+from iggtools.models.uhgg import UHGG
+from iggtools.params import outputs
+from iggtools.import_uhgg import decode_genomes_arg
+import gffutils
+import Bio.SeqIO
+
+
+# Up to this many concurrent species builds.
+CONCURRENT_GENOME_BUILDS = Semaphore(20)
+
+
+def annotations_file(genome_id, species_id, filename):
+    # s3://microbiome-igg/2.0/prodigal/GUT_GENOMEDDDDDD.{fna, faa, gff, log}
+    return f"{outputs.annotations}/{species_id}/{genome_id}/{filename}"
+
+
+@retry
+def find_files_with_retry(f):
+    return find_files(f)
+
+
+## Where should I put this read in sequence file depends on the usage, let's circle back this on Thursday
+#fasta_file = "/Users/chunyu.zhao/Desktop/20210104_test/GUT_GENOME000001/GUT_GENOME000001.ffn"
+def read_gene_sequence(fasta_file, species_id):
+    """ Scan the genome file to get contig_id and contig_seq as ref_seq """
+    contigs = {}
+    with InputStream(fasta_file) as file:
+        for rec in Bio.SeqIO.parse(file, 'fasta'):
+            contigs[rec.id] = {
+                "species_id": species_id,
+                "contig_id": rec.id,
+                "contig_len": len(rec.seq),
+                "contig_seq": str(rec.seq),
+            }
+    return contigs
+
+
+#gff3_file = "/Users/chunyu.zhao/Desktop/20210104_test/GUT_GENOME000001/GUT_GENOME000001.gff"
+def reformat_gene_features(gff3_file, genes_file):
+    # Convert GFF3 features into format desired by MIDAS
+    db = gffutils.create_db(gff3_file, ':memory')
+
+    with OutputStream(genes_file) as stream:
+        stream.write("\t".join(["gene_id", "contig_id", "start", "end", "strand", "gene_type"]) + "\n")
+        for feature in db.all_features():
+            if feature.source == "prokka":
+                continue
+            scaffold_id = feature.id.replace(">gnl|Prokka|", "")
+            start = feature.start - 1
+            stop = feature.stop
+            strand = feature.strand
+            gene_id = feature.attributes['ID'][0]
+            locus_tag = feature.attributes['locus_tag'][0]
+            assert gene_id == locus_tag
+            gene_type = feature.featuretype
+            stream.write("\t".join([gene_id, scaffold_id, str(start), str(end), strand, gene_type]) + "\n")
+    return True
+
+
+def build_gene_features(args):
+    if args.zzz_slave_toc:
+        build_gene_features_slave(args)
+    else:
+        build_gene_features_master(args)
+
+
+def build_gene_features_master(args):
+
+    # Fetch table of contents from s3.
+    # This will be read separately by each species build subcommand, so we make a local copy.
+    local_toc = download_reference(outputs.genomes)
+    db = UHGG(local_toc)
+    species_for_genome = db.genomes
+
+
+    def genome_work(genome_id):
+        assert genome_id in species_for_genome, f"Genome {genome_id} is not in the database."
+        species_id = species_for_genome[genome_id]
+
+        # The species build will upload this file last, after everything else is successfully uploaded.
+        # Therefore, if this file exists in s3, there is no need to redo the species build.
+        dest_file = annotations_file(genome_id, species_id, f"{genome_id}.genes.lz4")
+        msg = f"Builing gene features for genome {genome_id} from species {species_id}."
+        if find_files_with_retry(dest_file):
+            if not args.force:
+                tsprint(f"Destination {dest_file} for genome {genome_id} gene features already exists.  Specify --force to overwrite.")
+                return
+            msg = msg.replace("Importing", "Reimporting")
+
+
+        with CONCURRENT_GENOME_BUILDS:
+            tsprint(msg)
+            slave_log = "build_gene_features.log"
+            slave_subdir = f"{species_id}__{genome_id}"
+            if not args.debug:
+                command(f"rm -rf {slave_subdir}")
+            if not os.path.isdir(slave_subdir):
+                command(f"mkdir {slave_subdir}")
+
+            # Recurisve call via subcommand.  Use subdir, redirect logs.
+            slave_cmd = f"cd {slave_subdir}; PYTHONPATH={pythonpath()} {sys.executable} -m iggtools build_gene_features --genome {genome_id} --zzz_slave_mode --zzz_slave_toc {os.path.abspath(local_toc)} {'--debug' if args.debug else ''} &>> {slave_log}"
+            with open(f"{slave_subdir}/{slave_log}", "w") as slog:
+                slog.write(msg + "\n")
+                slog.write(slave_cmd + "\n")
+            try:
+                command(slave_cmd)
+            finally:
+                # Cleanup should not raise exceptions of its own, so as not to interfere with any
+                # prior exceptions that may be more informative.  Hence check=False.
+                upload(f"{slave_subdir}/{slave_log}", annotations_file(genome_id, species_id, slave_log + ".lz4"), check=False)
+                if not args.debug:
+                    command(f"rm -rf {slave_subdir}", check=False)
+
+    genome_id_list = decode_genomes_arg(args, species_for_genome)
+    multithreading_map(genome_work, genome_id_list, num_threads=20)
+
+
+def build_gene_features_slave(args):
+    """
+    https://github.com/czbiohub/iggtools/wiki
+    """
+
+    violation = "Please do not call build_gene_features_slave directly.  Violation"
+    assert args.zzz_slave_mode, f"{violation}:  Missing --zzz_slave_mode arg."
+    assert os.path.isfile(args.zzz_slave_toc), f"{violation}: File does not exist: {args.zzz_slave_toc}"
+
+    db = UHGG(args.zzz_slave_toc)
+    species_for_genome = db.genomes
+
+    genome_id = args.genomes
+    species_id = species_for_genome[genome_id]
+
+    annot_file = f"{genome_id}.gff"
+    download_reference(annotations_file(genome_id, species_id, f"{annot_file}.lz4"))
+
+    out_file = f"{genome_id}.genes"
+    dest_file = annotations_file(genome_id, species_id, f"{out_file}.lz4")
+    tsprint(dest_file)
+    command(f"aws s3 rm --recursive {dest_file.rsplit('/', 1)[0]}")
+
+    assert reformat_gene_features(annot_file, out_file)
+    upload(out_file, dest_file)
+
+
+def register_args(main_func):
+    subparser = add_subcommand('build_gene_features', main_func, help='convert GFF into desired format')
+    subparser.add_argument('--genomes',
+                           dest='genomes',
+                           required=False,
+                           help="genome[,genome...] to import;  alternatively, slice in format idx:modulus, e.g. 1:30, meaning annotate genomes whose ids are 1 mod 30; or, the special keyword 'all' meaning all genomes")
+    subparser.add_argument('--zzz_slave_toc',
+                           dest='zzz_slave_toc',
+                           required=False,
+                           help=SUPPRESS) # "reserved to pass table of contents from master to slave"
+    return main_func
+
+
+@register_args
+def main(args):
+    tsprint(f"Executing iggtools subcommand {args.subcommand} with args {vars(args)}.")
+    build_gene_features(args)

--- a/iggtools/subcommands/build_gene_features.py
+++ b/iggtools/subcommands/build_gene_features.py
@@ -24,23 +24,6 @@ def find_files_with_retry(f):
     return find_files(f)
 
 
-## Where should I put this read in sequence file depends on the usage, let's circle back this on Thursday
-#fasta_file = "/Users/chunyu.zhao/Desktop/20210104_test/GUT_GENOME000001/GUT_GENOME000001.ffn"
-def read_gene_sequence(fasta_file, species_id):
-    """ Scan the genome file to get contig_id and contig_seq as ref_seq """
-    contigs = {}
-    with InputStream(fasta_file) as file:
-        for rec in Bio.SeqIO.parse(file, 'fasta'):
-            contigs[rec.id] = {
-                "species_id": species_id,
-                "contig_id": rec.id,
-                "contig_len": len(rec.seq),
-                "contig_seq": str(rec.seq),
-            }
-    return contigs
-
-
-#gff3_file = "/Users/chunyu.zhao/Desktop/20210104_test/GUT_GENOME000001/GUT_GENOME000001.gff"
 def reformat_gene_features(gff3_file, genes_file):
     # Convert GFF3 features into format desired by MIDAS
     db = gffutils.create_db(gff3_file, f"{gff3_file}.db")

--- a/iggtools/subcommands/build_gene_features.py
+++ b/iggtools/subcommands/build_gene_features.py
@@ -11,7 +11,7 @@ import Bio.SeqIO
 
 
 # Up to this many concurrent species builds.
-CONCURRENT_GENOME_BUILDS = Semaphore(20)
+CONCURRENT_GENOME_BUILDS = Semaphore(48)
 
 
 def annotations_file(genome_id, species_id, filename):
@@ -49,6 +49,8 @@ def reformat_gene_features(gff3_file, genes_file):
         stream.write("\t".join(["gene_id", "contig_id", "start", "end", "strand", "gene_type"]) + "\n")
         for feature in db.all_features():
             if feature.source == "prokka":
+                continue
+            if "ID" not in feature.attributes: #CRISPR
                 continue
             seqid = feature.seqid.replace("gnl|Prokka|", "")
             start = feature.start - 1
@@ -117,7 +119,7 @@ def build_gene_features_master(args):
                     command(f"rm -rf {slave_subdir}", check=False)
 
     genome_id_list = decode_genomes_arg(args, species_for_genome)
-    multithreading_map(genome_work, genome_id_list, num_threads=20)
+    multithreading_map(genome_work, genome_id_list, num_threads=48)
 
 
 def build_gene_features_slave(args):

--- a/iggtools/subcommands/build_gene_features.py
+++ b/iggtools/subcommands/build_gene_features.py
@@ -35,8 +35,8 @@ def reformat_gene_features(gff3_file, genes_file):
                 continue
             if "ID" not in feature.attributes: #CRISPR
                 continue
-            seqid = feature.seqid.replace("gnl|Prokka|", "")
-            start = feature.start - 1
+            seqid = feature.seqid.replace("gnl|Prokka|", "") ## TODO: remove this replace
+            start = feature.start
             stop = feature.stop
             strand = feature.strand
             gene_id = feature.attributes['ID'][0]

--- a/iggtools/subcommands/midas_merge_snps.py
+++ b/iggtools/subcommands/midas_merge_snps.py
@@ -658,9 +658,6 @@ def midas_merge_snps(args):
         assert len(species_ids_of_interest) > 0, f"No (specified) species pass the genome_coverage filter across samples, please adjust the genome_coverage or species_list"
         tsprint(species_ids_of_interest)
 
-        species_ids_of_interest = species_ids_of_interest[:1]
-        dict_of_species = {species_ids_of_interest[0]: dict_of_species[species_ids_of_interest[0]]}
-
         pool_of_samples.create_dirs(["outdir", "tempdir"], args.debug)
         pool_of_samples.create_species_subdirs(species_ids_of_interest, "outdir", args.debug)
         pool_of_samples.create_species_subdirs(species_ids_of_interest, "tempdir", args.debug)

--- a/iggtools/subcommands/midas_merge_snps.py
+++ b/iggtools/subcommands/midas_merge_snps.py
@@ -1,11 +1,11 @@
-import sys
+
 import json
 from collections import defaultdict
 from operator import itemgetter
 import multiprocessing
 from math import ceil
-import Bio.SeqIO
 from bisect import bisect
+import Bio.SeqIO
 
 from iggtools.models.samplepool import SamplePool
 from iggtools.common.utils import tsprint, num_physical_cores, command, InputStream, OutputStream, multiprocessing_map, multithreading_map, select_from_tsv
@@ -151,22 +151,22 @@ def acgt_string(A, C, G, T):
 def translate(codon):
     """ Translate individual codon """
     codontable = {
-    'ATA':'I', 'ATC':'I', 'ATT':'I', 'ATG':'M',
-    'ACA':'T', 'ACC':'T', 'ACG':'T', 'ACT':'T',
-    'AAC':'N', 'AAT':'N', 'AAA':'K', 'AAG':'K',
-    'AGC':'S', 'AGT':'S', 'AGA':'R', 'AGG':'R',
-    'CTA':'L', 'CTC':'L', 'CTG':'L', 'CTT':'L',
-    'CCA':'P', 'CCC':'P', 'CCG':'P', 'CCT':'P',
-    'CAC':'H', 'CAT':'H', 'CAA':'Q', 'CAG':'Q',
-    'CGA':'R', 'CGC':'R', 'CGG':'R', 'CGT':'R',
-    'GTA':'V', 'GTC':'V', 'GTG':'V', 'GTT':'V',
-    'GCA':'A', 'GCC':'A', 'GCG':'A', 'GCT':'A',
-    'GAC':'D', 'GAT':'D', 'GAA':'E', 'GAG':'E',
-    'GGA':'G', 'GGC':'G', 'GGG':'G', 'GGT':'G',
-    'TCA':'S', 'TCC':'S', 'TCG':'S', 'TCT':'S',
-    'TTC':'F', 'TTT':'F', 'TTA':'L', 'TTG':'L',
-    'TAC':'Y', 'TAT':'Y', 'TAA':'_', 'TAG':'_',
-    'TGC':'C', 'TGT':'C', 'TGA':'_', 'TGG':'W',
+        'ATA':'I', 'ATC':'I', 'ATT':'I', 'ATG':'M',
+        'ACA':'T', 'ACC':'T', 'ACG':'T', 'ACT':'T',
+        'AAC':'N', 'AAT':'N', 'AAA':'K', 'AAG':'K',
+        'AGC':'S', 'AGT':'S', 'AGA':'R', 'AGG':'R',
+        'CTA':'L', 'CTC':'L', 'CTG':'L', 'CTT':'L',
+        'CCA':'P', 'CCC':'P', 'CCG':'P', 'CCT':'P',
+        'CAC':'H', 'CAT':'H', 'CAA':'Q', 'CAG':'Q',
+        'CGA':'R', 'CGC':'R', 'CGG':'R', 'CGT':'R',
+        'GTA':'V', 'GTC':'V', 'GTG':'V', 'GTT':'V',
+        'GCA':'A', 'GCC':'A', 'GCG':'A', 'GCT':'A',
+        'GAC':'D', 'GAT':'D', 'GAA':'E', 'GAG':'E',
+        'GGA':'G', 'GGC':'G', 'GGG':'G', 'GGT':'G',
+        'TCA':'S', 'TCC':'S', 'TCG':'S', 'TCT':'S',
+        'TTC':'F', 'TTT':'F', 'TTA':'L', 'TTG':'L',
+        'TAC':'Y', 'TAT':'Y', 'TAA':'_', 'TAG':'_',
+        'TGC':'C', 'TGT':'C', 'TGA':'_', 'TGG':'W',
     }
     return codontable[str(codon)]
 
@@ -174,21 +174,21 @@ def translate(codon):
 def complement(base):
     """ Complement nucleotide """
     d = {'A':'T', 'T':'A', 'G':'C', 'C':'G'}
-    if base in d: return d[base]
-    else: return base
+    if base in d:
+        return d[base]
+    return base
 
 
 def rev_comp(seq):
     """ Reverse complement sequence """
-    return(''.join([complement(base) for base in list(seq[::-1])]))
+    return ''.join([complement(base) for base in list(seq[::-1])])
 
 
 def get_gen_seq(genome_seq, start, end, strand):
     seq = genome_seq[start-1 : end]
     if strand == "-":
         return rev_comp(seq)
-    else:
-        return seq
+    return seq
 
 
 def index_replace(codon, allele, pos, strand):
@@ -248,8 +248,7 @@ def check_gene_sequences(contig_file, features, gene_seqs, species_id):
     ## Check if the
     contig_seqs = scan_contigs(contig_file, species_id)
     flags = dict()
-    for ref_id in contig_seqs.keys():
-        c = contig_seqs[ref_id]
+    for ref_id, c in contig_seqs.items():
         f = features[ref_id]
         for gid, gdict in f.items():
             flags[gid] = gene_seqs[gid]["gene_seq"] == get_gen_seq(c["contig_seq"], gdict['start'], gdict['end'], gdict['strand'])
@@ -271,9 +270,9 @@ def generate_boundaries(features):
     for contig_id in features.keys():
         feature_per_contig = features[contig_id]
         # Sort features by starting position
-        feature_per_contig_sorted = dict(sorted(feature_per_contig.items(), key = feature_per_contig.get("start"), reverse=False))
+        feature_per_contig_sorted = dict(sorted(feature_per_contig.items(), key=feature_per_contig.get("start"), reverse=False))
         ## Temp fix: we don't need python index, we need actual range boundaries
-        feature_ranges = { gf['gene_id']: (gf['start'], gf['end']) for gf in feature_per_contig_sorted.values() } ## +1 double check
+        feature_ranges = {gf['gene_id']: (gf['start'], gf['end']) for gf in feature_per_contig_sorted.values()} ## +1 double check
         # TODO: double check non-overlapping ranges before flatten
         feature_ranges_flat = tuple(_ for rt in tuple(feature_ranges.values()) for _ in rt)
         # Convert ranges into half-open intervals.
@@ -285,7 +284,7 @@ def generate_boundaries(features):
 
 def compute_degenracy(ref_codon, within_codon_position, strand):
     amino_acids = []
-    for allele in ['A','C','G','T']: # + strand
+    for allele in ['A', 'C', 'G', 'T']: # + strand
         codon = index_replace(ref_codon, allele, within_codon_position, strand) # +/- strand
         amino_acid = translate(codon)
         amino_acids.append(amino_acid)
@@ -302,7 +301,7 @@ def annotate_site(ref_id, ref_pos, curr_contig, curr_feature, gene_seqs):
     index = binary_search_site(curr_contig["boundaries"], ref_pos)
     if index is None:
         locus_type = "IGR" # even: intergenic
-        return locus_type,
+        return (locus_type,)
 
     curr_gene_id = curr_contig["genes"][index-1]
     curr_gene = curr_feature[curr_gene_id]
@@ -314,7 +313,7 @@ def annotate_site(ref_id, ref_pos, curr_contig, curr_feature, gene_seqs):
     curr_seq = gene_seqs[curr_gene_id]["gene_seq"]
     assert len(curr_seq) % 3 == 0, f"gene must by divisible by 3 to id codons"
     ref_codon, within_codon_position = fetch_ref_codon(ref_pos, curr_gene, curr_seq)
-    assert all(_ in ['A','T','C','G'] for _ in ref_codon), f"codon {ref_codon} for {ref_id}-{ref_pos} contain weird characters"
+    assert all(_ in ['A', 'T', 'C', 'G'] for _ in ref_codon), f"codon {ref_codon} for {ref_id}-{ref_pos} contain weird characters"
 
     site_type, amino_acids = compute_degenracy(ref_codon, within_codon_position, curr_gene['strand'])
     return locus_type, curr_gene_id, site_type, amino_acids
@@ -572,7 +571,7 @@ def compute_and_write_pooled_snps(accumulator, total_samples_count, species_id, 
             ref_id, ref_pos, ref_allele = site_id.rsplit("|", 2)
             ref_pos = int(ref_pos) # ref_pos is 1-based
             if ref_id not in gene_boundaries:
-                annots = "IGR", ## short contigs may not carry any gene
+                annots = ("IGR",) ## short contigs may not carry any gene
             else:
                 curr_contig = gene_boundaries[ref_id]
                 curr_feature = features_by_contig[ref_id]
@@ -655,7 +654,7 @@ def midas_merge_snps(args):
         pool_of_samples = SamplePool(args.samples_list, args.midas_outdir, "snps")
         dict_of_species = pool_of_samples.select_species("snps", args)
         species_ids_of_interest = [sp.id for sp in dict_of_species.values()]
-        assert len(species_ids_of_interest) > 0, f"No (specified) species pass the genome_coverage filter across samples, please adjust the genome_coverage or species_list"
+        assert species_ids_of_interest, f"No (specified) species pass the genome_coverage filter across samples, please adjust the genome_coverage or species_list"
         tsprint(species_ids_of_interest)
 
         pool_of_samples.create_dirs(["outdir", "tempdir"], args.debug)

--- a/iggtools/subcommands/midas_merge_snps.py
+++ b/iggtools/subcommands/midas_merge_snps.py
@@ -571,10 +571,13 @@ def compute_and_write_pooled_snps(accumulator, total_samples_count, species_id, 
             # Annotate one site
             ref_id, ref_pos, ref_allele = site_id.rsplit("|", 2)
             ref_pos = int(ref_pos) # ref_pos is 1-based
-            assert ref_id in gene_boundaries, f"Contig {ref_id} is not in the boundaries dict"
-            curr_contig = gene_boundaries[ref_id]
-            curr_feature = features_by_contig[ref_id]
-            annots = annotate_site(ref_id, ref_pos, curr_contig, curr_feature, gene_seqs)
+            if ref_id not in gene_boundaries:
+                annots = "IGR", ## short contigs may not carry any gene
+            else:
+                curr_contig = gene_boundaries[ref_id]
+                curr_feature = features_by_contig[ref_id]
+                annots = annotate_site(ref_id, ref_pos, curr_contig, curr_feature, gene_seqs)
+
             locus_type = annots[0]
             gene_id = annots[1] if len(annots) > 1 else None
             site_type = annots[2] if len(annots) > 2 else None

--- a/iggtools/subcommands/midas_run_snps.py
+++ b/iggtools/subcommands/midas_run_snps.py
@@ -458,7 +458,7 @@ def midas_run_snps(args):
 
         # Fetch representative genome fastas for each species (multiprocessing)
         midas_iggdb = MIDAS_IGGDB(args.midas_iggdb if args.midas_iggdb else sample.get_target_layout("midas_iggdb_dir"), args.num_cores)
-        contigs_files = midas_iggdb.fetch_files("contigs", species_ids_of_interest)
+        contigs_files = midas_iggdb.fetch_files("prokka_genome", species_ids_of_interest) #contigs
         tsprint(contigs_files)
 
         # Build Bowtie indexes for species in the restricted species profile

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -30,7 +30,7 @@ python -m iggtools midas_merge_species --samples_list samples_list.tsv ${merge_m
 
 
 echo "test build_bowtie2: select species by prevalence"
-python -m iggtools build_bowtie2_indexes --midas_iggdb ${merge_midas_outdir} --species_profile ${merge_midas_outdir}/species/species_prevalence.tsv --select_by sample_counts --select_threshold 2 --num_cores ${num_cores}  --debug ${merge_midas_outdir}/bt2_indexes &> ${logs_dir}/build_bowtie2.log
+python -m iggtools build_bowtie2_indexes --midas_iggdb ${merge_midas_outdir} --species_profile ${merge_midas_outdir}/species/species_prevalence.tsv --select_by sample_counts --select_threshold 2 --num_cores ${num_cores} --bt2_indexes_dir ${merge_midas_outdir}/bt2_indexes --debug &> ${logs_dir}/build_bowtie2.log
 
 
 echo "test midas_merge_snps default"

--- a/tests/samples_list.tsv
+++ b/tests/samples_list.tsv
@@ -1,4 +1,4 @@
 sample_name	midas_outdir
-sample1	/Users/cz/Desktop/iggtools/tests/my_midas_output_default
-sample2	/Users/cz/Desktop/iggtools/tests/my_midas_output_default
-sample3	/Users/cz/Desktop/iggtools/tests/my_midas_output_default
+sample1	/mnt/cz/iggtools/tests/my_midas_output_default
+sample2	/mnt/cz/iggtools/tests/my_midas_output_default
+sample3	/mnt/cz/iggtools/tests/my_midas_output_default

--- a/tests/samples_list.tsv
+++ b/tests/samples_list.tsv
@@ -1,4 +1,4 @@
 sample_name	midas_outdir
-sample1	/mnt/chunyu/iggtools/tests/my_midas_output_default
-sample2	/mnt/chunyu/iggtools/tests/my_midas_output_default
-sample3	/mnt/chunyu/iggtools/tests/my_midas_output_default
+sample1	/Users/cz/Desktop/iggtools/tests/my_midas_output_default
+sample2	/Users/cz/Desktop/iggtools/tests/my_midas_output_default
+sample3	/Users/cz/Desktop/iggtools/tests/my_midas_output_default


### PR DESCRIPTION
In this PR, we added the gene annotation of representative genome for given `{species_id}` to the midas_merge_snps workflow. To be specific, four columns were added to the one of the output file: `{species_id}.snps_info.tsv`:
- `locus_type`: IGR, CDS, tRNA and etc
- `gene_id: gene id generated by Prokka if locus_type is CDS
- `site_type`: degeneracy
- `amino_acids`: amino acids encoded by 4 possible alleles

We also added a subcommand `build_gene_features` to convert the Prokka GFF format into genes features desired by [MIDAS](https://github.com/snayfach/MIDAS/blob/master/docs/build_db.md) . For each genome, the generated output is saved in `s3://microbiome-igg/2.0/genes_annotations/{species_id}/{genome_id}.genes}. 
The `build_gene_features` command can be merge into `annotate_genes` [issue 45](https://github.com/czbiohub/iggtools/issues/45).

For a given genomic position, in order to locate the gene carrying that position, we first converted the list of gene ranges into a list of half-open gene boundaries, and used binary search to find the range that given position fell into. If return even index, then the given position fell between two genes, return "IGR"; if return odd, then the given position fell within one gene, return corresponding `gene_type` as the `locus_type`. 

Passed the unit test.
```
python -m iggtools midas_merge_snps --samples_list samples_list.tsv --num_cores 4 merged_midas_output
```
