### PR TITLE
Add --no-sign-request flag to 'aws s3 cp'

### DIFF
--- a/iggtools/common/utils.py
+++ b/iggtools/common/utils.py
@@ -640,7 +640,7 @@ def download_reference(ref_path, local_dir="."):
     if not os.path.exists(local_dir):
         command(f"mkdir -p {local_dir}")
     try:
-        command(f"set -o pipefail; aws s3 cp --only-show-errors {ref_path} - | {uncompress_cmd} > {local_path}")
+        command(f"set -o pipefail; aws s3 cp --only-show-errors --no-sign-request {ref_path} - | {uncompress_cmd} > {local_path}")
     except:
         command(f"rm -f {local_path}")
         raise


### PR DESCRIPTION
Here's the minimum-viable patch to iggtools that allows me to download with `aws s3 cp --only-show-errors --no-sign-request s3://microbiome-igg/<SOME-FILE-PATH>`.

When the new flag is excluded I get download failures like the following:

```
1629844368.0:  'aws s3 cp --only-show-errors s3://microbiome-igg/2.0/pangenomes/100022/centroids.ffn.lz4 - | lz4 -dc > ref/IGGdb2.0/pangenomes/100022/centroi
ds.ffn'
download failed: s3://microbiome-igg/2.0/pangenomes/100022/centroids.ffn.lz4 to - Unable to locate credentials
1629844532.5:  'rm -f ref/IGGdb2.0/pangenomes/100022/centroids.ffn'
1629844533.5:  Sleeping 54.31506110122879 seconds before retry 1 of <function download_reference at 0x7f1062e56d40> with ('s3://microbiome-igg/2.0/pangenomes
/100022/centroids.ffn.lz4', 'ref/IGGdb2.0/pangenomes/100022'), {}.
```